### PR TITLE
Remove pipe at beginning of comment to make Haddock happy

### DIFF
--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -134,7 +134,7 @@ partitionExDefs =
 data TypeSystemDefinition
   = TypeSystemDefinitionSchema !SchemaDefinition
   | TypeSystemDefinitionType !TypeDefinition
-  -- | TypeSystemDefinitionDir !DirectiveDefinition
+  -- TypeSystemDefinitionDir !DirectiveDefinition
   deriving (Ord, Show, Eq, Lift, Generic)
 
 instance Hashable TypeSystemDefinition


### PR DESCRIPTION
The pipe character at the beginning of this comment causes Haddock to fail, so this two-character change just removes the pipe so that it doesn’t.