### PR TITLE
Add missing parser for TypeSystemDefinition 👩🏼‍🎤

### DIFF
--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -60,10 +60,10 @@ parseExecutableDoc = runParser executableDocument
 
 -- | Parser for a 'AST.SchemaDefinition'.
 schemaDefinition :: Parser AST.SchemaDefinition
-schemaDefinition = tok "schema" *> braces (
+schemaDefinition = tok "schema" *> (
     AST.SchemaDefinition
       <$> optional directives
-      <*> many1 rootOperationTypeDefinition
+      <*> braces (many1 rootOperationTypeDefinition)
   )
 
 -- | Parser for a 'AST.RootOperationTypeDefinition'.

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -4,15 +4,15 @@
 
 module Keywords (primitiveTests) where
 
-import Hedgehog
-import Protolude
-import GHC.Base (fail)
+import           GHC.Base                            (fail)
+import           Hedgehog
+import           Protolude
 
-import Language.GraphQL.Draft.Syntax
-import Language.GraphQL.Draft.Parser
+import           Language.GraphQL.Draft.Parser
+import           Language.GraphQL.Draft.Syntax
 
-import qualified Language.GraphQL.Draft.Printer.Text as PP.TB
 import qualified Language.GraphQL.Draft.Printer      as P
+import qualified Language.GraphQL.Draft.Printer.Text as PP.TB
 
 primitiveTests :: IsString s => [(s, Property)]
 primitiveTests =
@@ -24,7 +24,7 @@ primitiveTests =
 propNullNameValue :: Property
 propNullNameValue = property $ either (fail . Protolude.show) (ast ===) astRoundTrip
   where
-    astRoundTrip = (runParser value) printed
+    astRoundTrip = runParser value printed
     printed      = PP.TB.render P.value ast
     ast          = VList (ListValueG { unListValue = [
                     VEnum (EnumValue{unEnumValue = Name{unName = "nullColumn"}})]})
@@ -32,7 +32,7 @@ propNullNameValue = property $ either (fail . Protolude.show) (ast ===) astRound
 propBoolNameValue :: Property
 propBoolNameValue = property $ either (fail . Protolude.show) (ast ===) astRoundTrip
   where
-    astRoundTrip = (runParser value) printed
+    astRoundTrip = runParser value printed
     printed      = PP.TB.render P.value ast
     ast          = VList (ListValueG { unListValue = [
                     VEnum (EnumValue{unEnumValue = Name{unName = "trueColumn"}})]})
@@ -40,6 +40,6 @@ propBoolNameValue = property $ either (fail . Protolude.show) (ast ===) astRound
 propNullNameName :: Property
 propNullNameName = property $ either (fail . Protolude.show) (ast ===) astRoundTrip
   where
-    astRoundTrip = (runParser nameParser) printed
+    astRoundTrip = runParser name printed
     printed      = PP.TB.render P.nameP ast
     ast          = Name "nullColumntwo"


### PR DESCRIPTION
Right now there is no parser to return a list of `TypeSystemDefinition`, which means this valid GraphQL schema _(according to the spec)_ is not parsed correctly:

```graphql
schema {
  query: Query
  mutation: Mutation
  subscription: Subscription
}
```

This was preventing us from having **subscriptions** in our GraphQL Haskell library!

We had to extend the Hasura parser to be able to do this, so I thought I might as well contribute it to the original repo! 😉 