### PR TITLE
Parse `Scientific` rather than `Int32` and `Double`

### DIFF
--- a/src/Language/GraphQL/Draft/Generator/Primitives.hs
+++ b/src/Language/GraphQL/Draft/Generator/Primitives.hs
@@ -6,6 +6,8 @@ import           Protolude
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
 
+import           Data.Scientific (fromFloatDigits)
+
 import           Language.GraphQL.Draft.Syntax
 
 
@@ -35,9 +37,9 @@ genValue =
   -- TODO: use maxbound of int32/double or something?
   Gen.recursive
   Gen.choice [ pure VNull
-             , VInt <$> Gen.int32 (Range.linear 1 99999)
+             , VScientific <$> fromIntegral <$> Gen.int32 (Range.linear 1 99999)
              , VEnum <$> genEnumValue
-             , VFloat <$> Gen.double (Range.linearFrac 1.1 999999.99999)
+             , VScientific <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VString <$> genStringValue
              , VBoolean <$> Gen.bool
              , VVariable <$> genVariable
@@ -69,12 +71,12 @@ genDefaultValue = genValueConst
 
 genValueConst :: Gen ValueConst
 genValueConst =
-  -- TODO: use maxbound of int32/double or something?
+  -- TODO: use maxbound of int64/double or something?
   Gen.recursive
   Gen.choice [ pure VCNull
-             , VCInt <$> Gen.int32 (Range.linear 1 9)
+             , VCScientific <$> fromIntegral <$> Gen.int32 (Range.linear 1 9)
              , VCEnum <$> genEnumValue
-             , VCFloat <$> Gen.double (Range.linearFrac 1.1 9.9)
+             , VCScientific <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VCString <$> genStringValue
              , VCBoolean <$> Gen.bool
              ]

--- a/src/Language/GraphQL/Draft/Generator/Primitives.hs
+++ b/src/Language/GraphQL/Draft/Generator/Primitives.hs
@@ -37,9 +37,9 @@ genValue =
   -- TODO: use maxbound of int32/double or something?
   Gen.recursive
   Gen.choice [ pure VNull
-             , VScientific <$> fromIntegral <$> Gen.int32 (Range.linear 1 99999)
+             , VInt <$> fromIntegral <$> Gen.int32 (Range.linear 1 99999)
              , VEnum <$> genEnumValue
-             , VScientific <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
+             , VFloat <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VString <$> genStringValue
              , VBoolean <$> Gen.bool
              , VVariable <$> genVariable
@@ -71,12 +71,12 @@ genDefaultValue = genValueConst
 
 genValueConst :: Gen ValueConst
 genValueConst =
-  -- TODO: use maxbound of int64/double or something?
+  -- TODO: use maxbound of int32/double or something?
   Gen.recursive
   Gen.choice [ pure VCNull
-             , VCScientific <$> fromIntegral <$> Gen.int32 (Range.linear 1 9)
+             , VCInt <$> fromIntegral <$> Gen.int32 (Range.linear 1 9)
              , VCEnum <$> genEnumValue
-             , VCScientific <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
+             , VCFloat <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VCString <$> genStringValue
              , VCBoolean <$> Gen.bool
              ]

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -13,12 +13,13 @@ import           Language.GraphQL.Draft.Syntax
 
 
 class (Monoid a, IsString a) => Printer a where
-  stringP     :: String -> a
-  textP       :: Text -> a
-  charP       :: Char -> a
-  scientificP :: Scientific -> a
+  stringP :: String -> a
+  textP   :: Text -> a
+  charP   :: Char -> a
+  intP    :: Integer -> a
+  floatP  :: Scientific -> a
 
-  {-# MINIMAL stringP, textP, charP, scientificP #-}
+  {-# MINIMAL stringP, textP, charP, intP, floatP #-}
 
   nameP    :: Name -> a
   nameP    = textP . unName
@@ -155,14 +156,15 @@ nonNull n = bool (charP '!') mempty $ unNullability n
 
 value :: (Printer a) => Value -> a
 value = \case
-  VVariable v    -> variable v
-  VScientific sc -> scientificP sc
-  VString s      -> stringValue s
-  VBoolean b     -> fromBool b
-  VNull          -> "null"
-  VList xs       -> listValue xs
-  VObject o      -> objectValue o
-  VEnum ev       -> nameP $ unEnumValue ev
+  VVariable v -> variable v
+  VInt i      -> intP i
+  VFloat sc   -> floatP sc
+  VString s   -> stringValue s
+  VBoolean b  -> fromBool b
+  VNull       -> "null"
+  VList xs    -> listValue xs
+  VObject o   -> objectValue o
+  VEnum ev    -> nameP $ unEnumValue ev
 
 stringValue :: (Printer a) => StringValue -> a
 stringValue (StringValue s) =
@@ -187,13 +189,14 @@ objectField (ObjectFieldG name val) =
 
 valueC :: (Printer a) => ValueConst -> a
 valueC = \case
-  VCScientific sc -> scientificP sc
-  VCString s      -> stringValue s
-  VCBoolean b     -> fromBool b
-  VCNull          -> "null"
-  VCList xs       -> listValueC xs
-  VCObject o      -> objectValueC o
-  VCEnum ev       -> nameP $ unEnumValue ev
+  VCInt i      -> intP i
+  VCFloat sc   -> floatP sc
+  VCString s   -> stringValue s
+  VCBoolean b  -> fromBool b
+  VCNull       -> "null"
+  VCList xs    -> listValueC xs
+  VCObject o   -> objectValueC o
+  VCEnum ev    -> nameP $ unEnumValue ev
 
 listValueC :: (Printer a) => ListValueC -> a
 listValueC (ListValueG xs) = mconcat [ charP '[' , li , charP ']' ]

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -7,18 +7,18 @@ module Language.GraphQL.Draft.Printer where
 
 import           Prelude                       (String)
 import           Protolude
+import           Data.Scientific               (Scientific)
 
 import           Language.GraphQL.Draft.Syntax
 
 
 class (Monoid a, IsString a) => Printer a where
-  stringP  :: String -> a
-  textP    :: Text -> a
-  charP    :: Char -> a
-  intP     :: Int32 -> a
-  doubleP  :: Double -> a
+  stringP     :: String -> a
+  textP       :: Text -> a
+  charP       :: Char -> a
+  scientificP :: Scientific -> a
 
-  {-# MINIMAL stringP, textP, charP, intP, doubleP #-}
+  {-# MINIMAL stringP, textP, charP, scientificP #-}
 
   nameP    :: Name -> a
   nameP    = textP . unName
@@ -155,15 +155,14 @@ nonNull n = bool (charP '!') mempty $ unNullability n
 
 value :: (Printer a) => Value -> a
 value = \case
-  VVariable v -> variable v
-  VInt i      -> intP i
-  VFloat d    -> doubleP d
-  VString s   -> stringValue s
-  VBoolean b  -> fromBool b
-  VNull       -> "null"
-  VList xs    -> listValue xs
-  VObject o   -> objectValue o
-  VEnum ev    -> nameP $ unEnumValue ev
+  VVariable v    -> variable v
+  VScientific sc -> scientificP sc
+  VString s      -> stringValue s
+  VBoolean b     -> fromBool b
+  VNull          -> "null"
+  VList xs       -> listValue xs
+  VObject o      -> objectValue o
+  VEnum ev       -> nameP $ unEnumValue ev
 
 stringValue :: (Printer a) => StringValue -> a
 stringValue (StringValue s) =
@@ -188,14 +187,13 @@ objectField (ObjectFieldG name val) =
 
 valueC :: (Printer a) => ValueConst -> a
 valueC = \case
-  VCInt i      -> intP i
-  VCFloat d    -> doubleP d
-  VCString s   -> stringValue s
-  VCBoolean b  -> fromBool b
-  VCNull       -> "null"
-  VCList xs    -> listValueC xs
-  VCObject o   -> objectValueC o
-  VCEnum ev    -> nameP $ unEnumValue ev
+  VCScientific sc -> scientificP sc
+  VCString s      -> stringValue s
+  VCBoolean b     -> fromBool b
+  VCNull          -> "null"
+  VCList xs       -> listValueC xs
+  VCObject o      -> objectValueC o
+  VCEnum ev       -> nameP $ unEnumValue ev
 
 listValueC :: (Printer a) => ListValueC -> a
 listValueC (ListValueG xs) = mconcat [ charP '[' , li , charP ']' ]

--- a/src/Language/GraphQL/Draft/Printer/ByteString.hs
+++ b/src/Language/GraphQL/Draft/Printer/ByteString.hs
@@ -21,8 +21,11 @@ instance Printer Builder where
   charP = charUtf8
   {-# INLINE charP #-}
 
-  scientificP = stringUtf8 . show
-  {-# INLINE scientificP #-}
+  intP = integerDec
+  {-# INLINE intP #-}
+
+  floatP = stringUtf8 . show
+  {-# INLINE floatP #-}
 
 
 render :: (a -> Builder) -> a -> BL.ByteString

--- a/src/Language/GraphQL/Draft/Printer/ByteString.hs
+++ b/src/Language/GraphQL/Draft/Printer/ByteString.hs
@@ -21,11 +21,8 @@ instance Printer Builder where
   charP = charUtf8
   {-# INLINE charP #-}
 
-  intP = int32Dec
-  {-# INLINE intP #-}
-
-  doubleP = doubleDec
-  {-# INLINE doubleP #-}
+  scientificP = stringUtf8 . show
+  {-# INLINE scientificP #-}
 
 
 render :: (a -> Builder) -> a -> BL.ByteString

--- a/src/Language/GraphQL/Draft/Printer/LazyText.hs
+++ b/src/Language/GraphQL/Draft/Printer/LazyText.hs
@@ -18,11 +18,8 @@ instance Printer Builder where
   charP   = singleton
   {-# INLINE charP #-}
 
-  intP    = fromString . show
-  {-# INLINE intP #-}
-
-  doubleP = fromString . show
-  {-# INLINE doubleP #-}
+  scientificP = fromString . show
+  {-# INLINE scientificP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/src/Language/GraphQL/Draft/Printer/LazyText.hs
+++ b/src/Language/GraphQL/Draft/Printer/LazyText.hs
@@ -18,8 +18,11 @@ instance Printer Builder where
   charP   = singleton
   {-# INLINE charP #-}
 
-  scientificP = fromString . show
-  {-# INLINE scientificP #-}
+  intP    = fromString . show
+  {-# INLINE intP #-}
+
+  floatP  = fromString . show
+  {-# INLINE floatP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/src/Language/GraphQL/Draft/Printer/Pretty.hs
+++ b/src/Language/GraphQL/Draft/Printer/Pretty.hs
@@ -37,11 +37,8 @@ instance Printer (Doc Text) where
   charP         = pretty
   {-# INLINE charP #-}
 
-  intP          = pretty
-  {-# INLINE intP #-}
-
-  doubleP       = pretty
-  {-# INLINE doubleP #-}
+  scientificP sc = pretty $ (show sc :: Text)
+  {-# INLINE scientificP #-}
 
   nameP         = pretty
   {-# INLINE nameP #-}

--- a/src/Language/GraphQL/Draft/Printer/Pretty.hs
+++ b/src/Language/GraphQL/Draft/Printer/Pretty.hs
@@ -37,8 +37,11 @@ instance Printer (Doc Text) where
   charP         = pretty
   {-# INLINE charP #-}
 
-  scientificP sc = pretty $ (show sc :: Text)
-  {-# INLINE scientificP #-}
+  intP          = pretty
+  {-# INLINE intP #-}
+
+  floatP sc = pretty $ (show sc :: Text)
+  {-# INLINE floatP #-}
 
   nameP         = pretty
   {-# INLINE nameP #-}

--- a/src/Language/GraphQL/Draft/Printer/Text.hs
+++ b/src/Language/GraphQL/Draft/Printer/Text.hs
@@ -17,8 +17,11 @@ instance Printer Builder where
   charP   = char
   {-# INLINE charP #-}
 
-  scientificP    = string . show
-  {-# INLINE scientificP #-}
+  intP    = decimal
+  {-# INLINE intP #-}
+
+  floatP    = text . show
+  {-# INLINE floatP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/src/Language/GraphQL/Draft/Printer/Text.hs
+++ b/src/Language/GraphQL/Draft/Printer/Text.hs
@@ -17,12 +17,8 @@ instance Printer Builder where
   charP   = char
   {-# INLINE charP #-}
 
-  intP    = decimal
-  {-# INLINE intP #-}
-
-  -- TODO: fixedDouble? is there any other function that we can use?
-  doubleP = fixedDouble 256
-  {-# INLINE doubleP #-}
+  scientificP    = string . show
+  {-# INLINE scientificP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -295,7 +295,7 @@ type TypeCondition = NamedType
 -- * Values
 
 -- data ValueLeaf
---   = VLInt !Int64
+--   = VLInt !Int32
 --   | VLFloat !Double
 --   | VLBoolean !Bool
 --   | VLString !StringValue
@@ -316,13 +316,14 @@ type TypeCondition = NamedType
 --   | VObject !ObjectValue
 --   deriving (Ord, Show, Eq, Lift)
 
--- Orphane instance allowing us to use Scientific values in Template Haskell
+-- Orphane instance allowing us to use Float values in Template Haskell
 -- Oxford brackets [| ... |]
 instance Lift S.Scientific where
   lift sc = return (LitE (RationalL (toRational sc)))
 
 data ValueConst
-  = VCScientific !S.Scientific
+  = VCInt !Integer
+  | VCFloat !S.Scientific
   | VCString !StringValue
   | VCBoolean !Bool
   | VCNull
@@ -335,7 +336,8 @@ instance Hashable ValueConst
 
 data Value
   = VVariable !Variable
-  | VScientific !S.Scientific
+  | VInt !Integer
+  | VFloat !S.Scientific
   | VString !StringValue
   | VBoolean !Bool
   | VNull

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -83,7 +83,7 @@ module Language.GraphQL.Draft.Syntax
 import           Control.Monad.Fail         (fail)
 import           Data.Bool                  (not)
 import           Instances.TH.Lift          ()
-import           Language.Haskell.TH.Syntax (Lift)
+import           Language.Haskell.TH.Syntax (Lift(..), Exp(LitE), Lit(RationalL))
 import           Protolude
 
 import qualified Data.Aeson                 as J
@@ -91,6 +91,7 @@ import qualified Data.Aeson.Types           as J
 import qualified Data.ByteString.Lazy       as BL
 import qualified Data.Text                  as T
 import qualified Text.Regex.TDFA            as TDFA
+import qualified Data.Scientific            as S
 
 -- * Documents
 
@@ -294,7 +295,7 @@ type TypeCondition = NamedType
 -- * Values
 
 -- data ValueLeaf
---   = VLInt !Int32
+--   = VLInt !Int64
 --   | VLFloat !Double
 --   | VLBoolean !Bool
 --   | VLString !StringValue
@@ -315,9 +316,13 @@ type TypeCondition = NamedType
 --   | VObject !ObjectValue
 --   deriving (Ord, Show, Eq, Lift)
 
+-- Orphane instance allowing us to use Scientific values in Template Haskell
+-- Oxford brackets [| ... |]
+instance Lift S.Scientific where
+  lift sc = return (LitE (RationalL (toRational sc)))
+
 data ValueConst
-  = VCInt !Int32
-  | VCFloat !Double
+  = VCScientific !S.Scientific
   | VCString !StringValue
   | VCBoolean !Bool
   | VCNull
@@ -330,8 +335,7 @@ instance Hashable ValueConst
 
 data Value
   = VVariable !Variable
-  | VInt !Int32
-  | VFloat !Double
+  | VScientific !S.Scientific
   | VString !StringValue
   | VBoolean !Bool
   | VNull

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -30,7 +30,7 @@ main = do
   case parseArgs args of
     TMQuick   -> runTest 20
     TMDev     -> runTest 100
-    TMRelease -> runTest 1000
+    TMRelease -> runTest 20
   where
     parseArgs = foldr parseArg TMDev
     parseArg str _ = case str of

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -30,7 +30,7 @@ main = do
   case parseArgs args of
     TMQuick   -> runTest 20
     TMDev     -> runTest 100
-    TMRelease -> runTest 20
+    TMRelease -> runTest 200
   where
     parseArgs = foldr parseArg TMDev
     parseArg str _ = case str of


### PR DESCRIPTION
As a first step towards addressing hasura/graphql-engine#576, we aim to parse all GraphQL numbers as `Scientific` values rather than `Int32` or `Double`. This allows graphql-engine to later decide which values are allowed.

Two ugly bits:
- I've added an orphan `Lift Scientific` instance.
- The `Printer` instances all use `show` to print `Scientific` values.

I am still very unfamiliar with Hasura's codebase, so please give ruthless feedback, please nitpick everything, and please point out (if necessary) that this is entirely the wrong approach.