### PR TITLE
Sketchy 'ConvertText Text ByteString' was removed from protolude 0.3

### DIFF
--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -237,7 +237,7 @@ stringValue = do
     -- Turns out this is really tricky, so we're going to cheat by
     -- reconstructing a literal string (by putting quotes around it) and
     -- delegating all the hard work to Aeson.
-    unescapeText str = A.parseOnly jstring ("\"" <> toS str <> "\"")
+    unescapeText str = A.parseOnly jstring ("\"" <> encodeUtf8 str <> "\"")
 
 -- Notice it can be empty
 listValueG :: Parser a -> Parser (AST.ListValueG a)


### PR DESCRIPTION
On the way to supporting ghc 8.10.1

I think this lib would be a little easier to maintain if we did away with `protolude`, but for another day...