### PR TITLE
Only convert Scientific to Integer for nonnegative exponents

### DIFF
--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -33,7 +33,7 @@ import           Data.Attoparsec.Text          (Parser, anyChar, char, many1,
 import qualified Data.Attoparsec.Text          as AT
 import           Data.Char                     (isAsciiLower, isAsciiUpper,
                                                 isDigit)
-import           Data.Scientific               (Scientific, base10Exponent)
+import           Data.Scientific               (Scientific)
 import           Data.Text                     (find)
 
 import qualified Language.GraphQL.Draft.Syntax as AST

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -188,21 +188,12 @@ valueConst = tok (
 number :: Parser (Either Scientific Integer)
 number = do
   (numText, num) <- match (tok scientific)
-  pure $ case Data.Text.find (== '.') numText of
-      -- Number specified with decimals, so store as a 'Scientific'
+  pure $ case Data.Text.find (\c -> c == '.' || c == 'e' || c == 'E') numText of
+      -- Number specified with decimals and/or scientific notation, so
+      -- store as a 'Scientific'.
     Just _ -> Left num
-      -- Even if there is no '.' in the text, the number may still not
-      -- be integral (e.g. in 3E-7).  Conversely, even a number with a
-      -- negative exponent may still be integral, e.g. 300E-2.  But
-      -- the careful thing to do is to only convert to an 'Integer'
-      -- for numbers with nonnegative exponents.  Note that we can't
-      -- simply delegate this decision to
-      -- 'Data.Scientific.floatingOrInteger' since 'Scientific' does
-      -- not have a 'RealFloat' instance.
-    Nothing ->
-      if base10Exponent num >= 0
-      then Right (floor num)
-      else Left num
+      -- No '.' and not in scientific notation, so safe to convert to integer.
+    Nothing -> Right (floor num)
 
 -- This will try to pick the first type it can runParser. If you are working with
 -- explicit types use the `typedValue` parser.


### PR DESCRIPTION
We use attoparsec's scientific number parsing code, which gives us a `Scientific` value. We like to work with `Integer`s when we can, and so we sometimes convert this  scientific number to an integer by simply taking its floor. But simply checking if the input text has a period symbol `.` in it does not suffice to check for correctness of this conversion, as numbers with a negative exponent may not be integral. This fixes that to only store numbers as integers if they have been supplied with a nonnegative exponent.

hasura/graphql-engine#4733 will be fixed by this (after we update the version of graphql-parser-hs used there).