### PR TITLE
Get rid of the Paths module as it is not used anywhere

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -63,7 +63,6 @@ library
       Language.GraphQL.Draft.Syntax
       Language.GraphQL.Draft.TH
   other-modules:
-      Paths_graphql_parser
   default-language: Haskell2010
 
 test-suite graphql-parser-test
@@ -100,7 +99,6 @@ benchmark graphql-parser-bench
   type: exitcode-stdio-1.0
   main-is: Benchmark.hs
   other-modules:
-      Paths_graphql_parser
   hs-source-dirs:
       bench
   default-extensions: NoImplicitPrelude


### PR DESCRIPTION
The Paths module seem to trigger recompilation in graphql-engine