### PR TITLE
template-haskell >= 2.16.0.0

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -43,7 +43,7 @@ library
     , hedgehog
     , prettyprinter
     , scientific
-    , template-haskell
+    , template-haskell >= 2.16.0.0
     , text
     , text-builder
     , th-lift-instances


### PR DESCRIPTION
because "liftTyped" first appears in that version

This means that the build on 8.8.4 (or earlier) will fail up-front with a configuration error message rather than running for 5 minutes and then presenting the user with a compiler error message.
