### PR TITLE
Fix fragment spread printing

### DIFF
--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -176,7 +176,7 @@ optAlias = maybe mempty (\a -> nameP a <> textP ": ")
 inlineFragment :: (Print (frag var), Print var, Printer a) => InlineFragment frag var -> a
 inlineFragment (InlineFragment tc ds sels) =
   "... "
-  <> maybe mempty ((textP "on" <>) . nameP) tc
+  <> maybe mempty ((textP "on " <>) . nameP) tc
   <> optempty directives ds
   <> selectionSetP sels
 


### PR DESCRIPTION
We need fragment spreads to be printed correctly since we use graphql-parser-hs to generate queries in heterogeneous execution (hasura/graphql-engine#5869). This adds a missing space.