### PR TITLE
fix incorrect semantics of TextShow

### DIFF
--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -108,7 +108,7 @@ instance Pretty Name where
   pretty = pretty. unName
 
 instance TextShow Name where
-  showb = showb . unName
+  showb = fromText . unName
 
 mkName :: Text -> Maybe Name
 mkName text = T.uncons text >>= \(first, body) ->
@@ -461,10 +461,7 @@ instance Hashable EnumValueDefinition
 
 newtype EnumValue
   = EnumValue { unEnumValue :: Name }
-  deriving (Show, Eq, Lift, Hashable, J.ToJSON, J.FromJSON, Ord)
-
-instance TextShow EnumValue where
-  showb = showb . unEnumValue
+  deriving (Show, TextShow, Eq, Lift, Hashable, J.ToJSON, J.FromJSON, Ord)
 
 data InputObjectTypeDefinition = InputObjectTypeDefinition
   { _iotdDescription      :: Maybe Description


### PR DESCRIPTION
`TextShow` behaves like `Show`, for strings: it surrounds them with `"`. This is not the behaviour we intended when introducing `TextShow`. We have two options:
- either we use `TextShow`, but use our own semantics for it: avoids introducing a `ToTxt` typeclass in the code of hge, but is dangerous wrt. automatic instances (this PR)
- either we revert the change entirely and go back to `ToTxt` (#39 )