### PR TITLE
Parametrize some of the type definitions and add printer instance for schema document

### DIFF
--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -168,7 +168,7 @@ genOperationType =
               , OperationTypeSubscription
               ]
 
-genTypeDefinition :: Gen (TypeDefinition ())
+genTypeDefinition :: Gen (TypeDefinition InputValueDefinition ())
 genTypeDefinition =
   Gen.choice [ TypeDefinitionScalar      <$> genScalarTypeDefinition
              , TypeDefinitionObject      <$> genObjectTypeDefinition
@@ -184,7 +184,7 @@ genScalarTypeDefinition = ScalarTypeDefinition
                           <*> genName
                           <*> genDirectives
 
-genObjectTypeDefinition :: Gen ObjectTypeDefinition
+genObjectTypeDefinition :: Gen (ObjectTypeDefinition InputValueDefinition)
 genObjectTypeDefinition = ObjectTypeDefinition
                           <$> Gen.maybe genDescription
                           <*> genName
@@ -192,7 +192,7 @@ genObjectTypeDefinition = ObjectTypeDefinition
                           <*> genDirectives
                           <*> genFieldDefinitions
 
-genInterfaceTypeDefinition :: Gen (InterfaceTypeDefinition ())
+genInterfaceTypeDefinition :: Gen (InterfaceTypeDefinition InputValueDefinition ())
 genInterfaceTypeDefinition = InterfaceTypeDefinition
                              <$> Gen.maybe genDescription
                              <*> genName
@@ -235,7 +235,7 @@ genEnumValueDefinition = EnumValueDefinition
                          <*> genEnumValue
                          <*> genDirectives
 
-genFieldDefinition :: Gen FieldDefinition
+genFieldDefinition :: Gen (FieldDefinition InputValueDefinition)
 genFieldDefinition = FieldDefinition
                      <$> Gen.maybe genDescription
                      <*> genName
@@ -243,17 +243,17 @@ genFieldDefinition = FieldDefinition
                      <*> genType
                      <*> genDirectives
 
-genFieldDefinitions :: Gen [FieldDefinition]
+genFieldDefinitions :: Gen [FieldDefinition InputValueDefinition]
 genFieldDefinitions = mkList genFieldDefinition
 
-genDirectiveDefinition :: Gen DirectiveDefinition
+genDirectiveDefinition :: Gen (DirectiveDefinition InputValueDefinition)
 genDirectiveDefinition = DirectiveDefinition
                          <$> Gen.maybe genDescription
                          <*> genName
                          <*> genArgumentsDefinition
                          <*> Gen.list (Range.linear 1 10) genDirectiveLocation
 
-genArgumentsDefinition :: Gen ArgumentsDefinition
+genArgumentsDefinition :: Gen (ArgumentsDefinition InputValueDefinition)
 genArgumentsDefinition = Gen.list (Range.linear 1 10) genInputValueDefinition
 
 genDirectiveLocation :: Gen DirectiveLocation

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -168,7 +168,7 @@ genOperationType =
               , OperationTypeSubscription
               ]
 
-genTypeDefinition :: Gen (TypeDefinition InputValueDefinition ())
+genTypeDefinition :: Gen (TypeDefinition () InputValueDefinition)
 genTypeDefinition =
   Gen.choice [ TypeDefinitionScalar      <$> genScalarTypeDefinition
              , TypeDefinitionObject      <$> genObjectTypeDefinition
@@ -192,7 +192,7 @@ genObjectTypeDefinition = ObjectTypeDefinition
                           <*> genDirectives
                           <*> genFieldDefinitions
 
-genInterfaceTypeDefinition :: Gen (InterfaceTypeDefinition InputValueDefinition ())
+genInterfaceTypeDefinition :: Gen (InterfaceTypeDefinition () InputValueDefinition)
 genInterfaceTypeDefinition = InterfaceTypeDefinition
                              <$> Gen.maybe genDescription
                              <*> genName

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -214,7 +214,7 @@ genEnumTypeDefinition = EnumTypeDefinition
                         <*> genDirectives
                         <*> mkList genEnumValueDefinition
 
-genInputObjectTypeDefinition :: Gen InputObjectTypeDefinition
+genInputObjectTypeDefinition :: Gen (InputObjectTypeDefinition InputValueDefinition)
 genInputObjectTypeDefinition = InputObjectTypeDefinition
                                <$> Gen.maybe genDescription
                                <*> genName

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -226,8 +226,8 @@ genInputValueDefinition = InputValueDefinition
                           <$> Gen.maybe genDescription
                           <*> genName
                           <*> genType
-                          <*> genDirectives
                           <*> Gen.maybe genValue
+                          <*> genDirectives
 
 genEnumValueDefinition :: Gen EnumValueDefinition
 genEnumValueDefinition = EnumValueDefinition

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -42,7 +42,7 @@ genExecutableDocument =
 
 genSchemaDocument :: Gen SchemaDocument
 genSchemaDocument =
-  SchemaDocument <$> Gen.list (Range.linear 1 5) genTypeDefinition
+  SchemaDocument <$> Gen.list (Range.linear 1 5) genTypeSystemDefinition
 
 
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -226,6 +226,7 @@ genInputValueDefinition = InputValueDefinition
                           <$> Gen.maybe genDescription
                           <*> genName
                           <*> genType
+                          <*> genDirectives
                           <*> Gen.maybe genValue
 
 genEnumValueDefinition :: Gen EnumValueDefinition

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -304,6 +304,7 @@ optDesc = optional (AST.Description <$> stringLiteral)
 objectTypeDefinition :: Parser (AST.ObjectTypeDefinition AST.InputValueDefinition)
 objectTypeDefinition = AST.ObjectTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "type"
   <*> nameParser
   <*> optempty interfaces
@@ -319,6 +320,7 @@ fieldDefinitions = braces $ many1 fieldDefinition
 fieldDefinition :: Parser (AST.FieldDefinition AST.InputValueDefinition)
 fieldDefinition = AST.FieldDefinition
   <$> optDesc
+  <*  whiteSpace
   <*> nameParser
   <*> optempty argumentsDefinition
   <*  tok ":"
@@ -331,6 +333,7 @@ argumentsDefinition = parens $ many1 inputValueDefinition
 interfaceTypeDefinition :: PossibleTypes pos => Parser (AST.InterfaceTypeDefinition pos AST.InputValueDefinition)
 interfaceTypeDefinition = AST.InterfaceTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "interface"
   <*> nameParser
   <*> optempty directives
@@ -340,6 +343,7 @@ interfaceTypeDefinition = AST.InterfaceTypeDefinition
 unionTypeDefinition :: Parser AST.UnionTypeDefinition
 unionTypeDefinition = AST.UnionTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "union"
   <*> nameParser
   <*> optempty directives
@@ -352,6 +356,7 @@ unionMembers = nameParser `sepBy1` tok "|"
 scalarTypeDefinition :: Parser AST.ScalarTypeDefinition
 scalarTypeDefinition = AST.ScalarTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "scalar"
   <*> nameParser
   <*> optempty directives
@@ -359,6 +364,7 @@ scalarTypeDefinition = AST.ScalarTypeDefinition
 enumTypeDefinition :: Parser AST.EnumTypeDefinition
 enumTypeDefinition = AST.EnumTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "enum"
   <*> nameParser
   <*> optempty directives
@@ -370,6 +376,7 @@ enumValueDefinitions = braces $ many1 enumValueDefinition
 enumValueDefinition :: Parser AST.EnumValueDefinition
 enumValueDefinition = AST.EnumValueDefinition
   <$> optDesc
+  <*  whiteSpace
   <*> enumValue
   <*> optempty directives
 
@@ -380,6 +387,7 @@ enumValue = AST.EnumValue <$> nameParser
 inputObjectTypeDefinition :: Parser (AST.InputObjectTypeDefinition AST.InputValueDefinition)
 inputObjectTypeDefinition = AST.InputObjectTypeDefinition
   <$> optDesc
+  <*  whiteSpace
   <*  tok "input"
   <*> nameParser
   <*> optempty directives
@@ -391,6 +399,7 @@ inputValueDefinitions = braces $ many1 inputValueDefinition
 inputValueDefinition :: Parser AST.InputValueDefinition
 inputValueDefinition = AST.InputValueDefinition
   <$> optDesc
+  <*  whiteSpace
   <*> nameParser
   <*  tok ":"
   <*> graphQLType

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -288,7 +288,7 @@ typeSystemDefinition =
 parseTypeSystemDefinitions :: Text -> Either Text [AST.TypeSystemDefinition]
 parseTypeSystemDefinitions = runParser $ many1 typeSystemDefinition
 
-typeDefinition :: Parser (AST.TypeDefinition ())
+typeDefinition :: Parser (AST.TypeDefinition AST.InputValueDefinition ())
 typeDefinition =
       AST.TypeDefinitionObject        <$> objectTypeDefinition
   <|> AST.TypeDefinitionInterface     <$> interfaceTypeDefinition
@@ -301,7 +301,7 @@ typeDefinition =
 optDesc :: Parser (Maybe AST.Description)
 optDesc = optional (AST.Description <$> stringLiteral)
 
-objectTypeDefinition :: Parser AST.ObjectTypeDefinition
+objectTypeDefinition :: Parser (AST.ObjectTypeDefinition AST.InputValueDefinition)
 objectTypeDefinition = AST.ObjectTypeDefinition
   <$> optDesc
   <*  tok "type"
@@ -313,10 +313,10 @@ objectTypeDefinition = AST.ObjectTypeDefinition
 interfaces :: Parser [AST.Name]
 interfaces = tok "implements" *> many1 nameParser
 
-fieldDefinitions :: Parser [AST.FieldDefinition]
+fieldDefinitions :: Parser [(AST.FieldDefinition AST.InputValueDefinition)]
 fieldDefinitions = braces $ many1 fieldDefinition
 
-fieldDefinition :: Parser AST.FieldDefinition
+fieldDefinition :: Parser (AST.FieldDefinition AST.InputValueDefinition)
 fieldDefinition = AST.FieldDefinition
   <$> optDesc
   <*> nameParser
@@ -325,10 +325,10 @@ fieldDefinition = AST.FieldDefinition
   <*> graphQLType
   <*> optempty directives
 
-argumentsDefinition :: Parser AST.ArgumentsDefinition
+argumentsDefinition :: Parser (AST.ArgumentsDefinition AST.InputValueDefinition)
 argumentsDefinition = parens $ many1 inputValueDefinition
 
-interfaceTypeDefinition :: PossibleTypes pos => Parser (AST.InterfaceTypeDefinition pos)
+interfaceTypeDefinition :: PossibleTypes pos => Parser (AST.InterfaceTypeDefinition AST.InputValueDefinition pos)
 interfaceTypeDefinition = AST.InterfaceTypeDefinition
   <$> optDesc
   <*  tok "interface"

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -5,10 +5,9 @@
 module Language.GraphQL.Draft.Parser
   ( executableDocument
   , parseExecutableDoc
-
   , schemaDocument
-  , parseSchemaDoc
   , parseTypeSystemDefinitions
+  , parseSchemaDocument
 
   , Variable(..)
   , value
@@ -58,10 +57,10 @@ parseExecutableDoc = runParser executableDocument
 
 -- | Parser for a schema document.
 schemaDocument :: Parser AST.SchemaDocument
-schemaDocument = whiteSpace *> (AST.SchemaDocument <$> many1 typeDefinition)
+schemaDocument = whiteSpace *> (AST.SchemaDocument <$> many1 typeSystemDefinition)
 
-parseSchemaDoc :: Text -> Either Text AST.SchemaDocument
-parseSchemaDoc = runParser schemaDocument
+parseSchemaDocument :: Text -> Either Text AST.SchemaDocument
+parseSchemaDocument = runParser schemaDocument
 
 definitionExecutable :: Parser (AST.ExecutableDefinition AST.Name)
 definitionExecutable =

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -394,6 +394,7 @@ inputValueDefinition = AST.InputValueDefinition
   <*> nameParser
   <*  tok ":"
   <*> graphQLType
+  <*> optempty directives
   <*> optional defaultValue
 
 -- * Internal

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -377,7 +377,7 @@ enumValueDefinition = AST.EnumValueDefinition
 enumValue :: Parser AST.EnumValue
 enumValue = AST.EnumValue <$> nameParser
 
-inputObjectTypeDefinition :: Parser AST.InputObjectTypeDefinition
+inputObjectTypeDefinition :: Parser (AST.InputObjectTypeDefinition AST.InputValueDefinition)
 inputObjectTypeDefinition = AST.InputObjectTypeDefinition
   <$> optDesc
   <*  tok "input"

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -8,6 +8,7 @@ module Language.GraphQL.Draft.Parser
 
   , schemaDocument
   , parseSchemaDoc
+  , parseTypeSystemDefinitions
 
   , Variable(..)
   , value
@@ -266,6 +267,24 @@ nullability =
   <|> pure (AST.Nullability True)
 
 -- * Type Definition
+
+rootOperationTypeDefinition :: Parser AST.RootOperationTypeDefinition
+rootOperationTypeDefinition =
+  AST.RootOperationTypeDefinition <$> operationTypeParser <*> nameParser
+
+schemaDefinition :: Parser AST.SchemaDefinition
+schemaDefinition = AST.SchemaDefinition
+  <$ tok "schema"
+  <*> optional directives
+  <*> many1 rootOperationTypeDefinition
+
+typeSystemDefinition :: Parser AST.TypeSystemDefinition
+typeSystemDefinition =
+  AST.TypeSystemDefinitionSchema <$> schemaDefinition
+  <|> AST.TypeSystemDefinitionType <$> typeDefinition
+
+parseTypeSystemDefinitions :: Text -> Either Text [AST.TypeSystemDefinition]
+parseTypeSystemDefinitions = runParser $ many1 typeSystemDefinition
 
 typeDefinition :: Parser (AST.TypeDefinition ())
 typeDefinition =

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -394,8 +394,8 @@ inputValueDefinition = AST.InputValueDefinition
   <*> nameParser
   <*  tok ":"
   <*> graphQLType
-  <*> optempty directives
   <*> optional defaultValue
+  <*> optempty directives
 
 -- * Internal
 

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -288,7 +288,7 @@ typeSystemDefinition =
 parseTypeSystemDefinitions :: Text -> Either Text [AST.TypeSystemDefinition]
 parseTypeSystemDefinitions = runParser $ many1 typeSystemDefinition
 
-typeDefinition :: Parser (AST.TypeDefinition AST.InputValueDefinition ())
+typeDefinition :: Parser (AST.TypeDefinition () AST.InputValueDefinition)
 typeDefinition =
       AST.TypeDefinitionObject        <$> objectTypeDefinition
   <|> AST.TypeDefinitionInterface     <$> interfaceTypeDefinition
@@ -328,7 +328,7 @@ fieldDefinition = AST.FieldDefinition
 argumentsDefinition :: Parser (AST.ArgumentsDefinition AST.InputValueDefinition)
 argumentsDefinition = parens $ many1 inputValueDefinition
 
-interfaceTypeDefinition :: PossibleTypes pos => Parser (AST.InterfaceTypeDefinition AST.InputValueDefinition pos)
+interfaceTypeDefinition :: PossibleTypes pos => Parser (AST.InterfaceTypeDefinition pos AST.InputValueDefinition)
 interfaceTypeDefinition = AST.InterfaceTypeDefinition
   <$> optDesc
   <*  tok "interface"

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -269,13 +269,16 @@ nullability =
 
 rootOperationTypeDefinition :: Parser AST.RootOperationTypeDefinition
 rootOperationTypeDefinition =
-  AST.RootOperationTypeDefinition <$> operationTypeParser <*> nameParser
+  AST.RootOperationTypeDefinition <$> operationTypeParser <* tok ":" <*> nameParser
 
 schemaDefinition :: Parser AST.SchemaDefinition
 schemaDefinition = AST.SchemaDefinition
   <$ tok "schema"
   <*> optional directives
-  <*> many1 rootOperationTypeDefinition
+  <*> rootOperationTypeDefinitions
+
+rootOperationTypeDefinitions :: Parser [AST.RootOperationTypeDefinition]
+rootOperationTypeDefinitions = braces $ many1 rootOperationTypeDefinition
 
 typeSystemDefinition :: Parser AST.TypeSystemDefinition
 typeSystemDefinition =

--- a/src/Language/GraphQL/Draft/Parser.hs-boot
+++ b/src/Language/GraphQL/Draft/Parser.hs-boot
@@ -5,3 +5,5 @@ import           Data.Text                     (Text)
 import {-# SOURCE #-} qualified Language.GraphQL.Draft.Syntax as AST
 
 parseExecutableDoc :: Text -> Either Text (AST.ExecutableDocument AST.Name)
+
+parseSchemaDocument :: Text -> Either Text AST.SchemaDocument

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -289,6 +289,14 @@ rootOperationTypeDefinition :: Printer a => RootOperationTypeDefinition -> a
 rootOperationTypeDefinition (RootOperationTypeDefinition opType rootName) =
   operationType opType <> ": " <> nameP rootName
 
+typeSystemDefinition :: Printer a => TypeSystemDefinition -> a
+typeSystemDefinition (TypeSystemDefinitionSchema schemaDefn) = schemaDefinition schemaDefn
+typeSystemDefinition (TypeSystemDefinitionType typeDefn) = typeDefinitionP typeDefn
+
+schemaDocument :: Printer a => SchemaDocument -> a
+schemaDocument (SchemaDocument typeDefns) =
+  mconcat $ intersperse (charP '\n') $ map typeSystemDefinition typeDefns
+
 typeDefinitionP :: Printer a => (TypeDefinition () InputValueDefinition) -> a
 typeDefinitionP (TypeDefinitionScalar scalarDefn) = scalarTypeDefinition scalarDefn
 typeDefinitionP (TypeDefinitionObject objDefn) = objectTypeDefinition objDefn

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -176,7 +176,7 @@ optAlias = maybe mempty (\a -> nameP a <> textP ": ")
 inlineFragment :: (Print (frag var), Print var, Printer a) => InlineFragment frag var -> a
 inlineFragment (InlineFragment tc ds sels) =
   "... "
-  <> maybe mempty ((textP "on" <>) . nameP) tc
+  <> maybe mempty ((textP "on " <>) . nameP) tc
   <> optempty directives ds
   <> selectionSetP sels
 

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -222,7 +222,7 @@ defaultValue v = " = " <> value v
 
 description :: Printer a => Maybe Description -> a
 description Nothing = mempty
-description (Just desc) = textP $ unDescription desc <> " \n"
+description (Just desc) = (stringValue $ unDescription desc) <> " \n"
 -- | Type Reference
 
 graphQLType :: Printer a => GType -> a

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -350,7 +350,7 @@ objectTypeDefinition (ObjectTypeDefinition desc name ifaces dirs fieldDefinition
 interfaceTypeDefinition :: Printer a => InterfaceTypeDefinition () InputValueDefinition -> a
 interfaceTypeDefinition (InterfaceTypeDefinition desc name dirs fieldDefinitions _possibleTypes) =
   -- `possibleTypes` are not included with an interface definition in a GraphQL IDL
-  "inteface "
+  "interface "
   <> nameP name
   <> charP ' '
   <> optempty directives dirs

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -220,6 +220,9 @@ variableDefinition (VariableDefinition var ty defVal) =
 defaultValue :: Printer a => Value Void -> a
 defaultValue v = " = " <> value v
 
+description :: Printer a => Maybe Description -> a
+description Nothing = mempty
+description (Just desc) = textP $ unDescription desc <> " \n"
 -- | Type Reference
 
 graphQLType :: Printer a => GType -> a
@@ -307,13 +310,16 @@ typeDefinitionP (TypeDefinitionInputObject inpObjDefn) = inputObjectTypeDefiniti
 
 scalarTypeDefinition :: Printer a => ScalarTypeDefinition -> a
 scalarTypeDefinition (ScalarTypeDefinition desc name dirs) =
-  -- TODO: handle description
-  "scalar " <> nameP name <> " " <> optempty directives dirs
+  description desc
+  <> "scalar "
+  <> nameP name
+  <> charP ' '
+  <> optempty directives dirs
 
 inputValueDefinition :: Printer a => InputValueDefinition -> a
 inputValueDefinition (InputValueDefinition desc name gType defVal dirs) =
-  -- TODO: handle description
-  nameP name
+  description desc
+  <> nameP name
   <> textP ": "
   <> graphQLType gType
   <> (maybe mempty defaultValue defVal)
@@ -322,7 +328,8 @@ inputValueDefinition (InputValueDefinition desc name gType defVal dirs) =
 
 fieldDefinition :: Printer a => FieldDefinition InputValueDefinition -> a
 fieldDefinition (FieldDefinition desc name args gType dirs) =
-  nameP name
+  description desc
+  <> nameP name
   <>
   case args of
     [] -> mempty
@@ -336,7 +343,8 @@ fieldDefinition (FieldDefinition desc name args gType dirs) =
 
 objectTypeDefinition :: Printer a => ObjectTypeDefinition InputValueDefinition -> a
 objectTypeDefinition (ObjectTypeDefinition desc name ifaces dirs fieldDefinitions) =
-  "type "
+  description desc
+  <> "type "
   <> nameP name
   <> optempty directives dirs
   <>
@@ -350,7 +358,8 @@ objectTypeDefinition (ObjectTypeDefinition desc name ifaces dirs fieldDefinition
 interfaceTypeDefinition :: Printer a => InterfaceTypeDefinition () InputValueDefinition -> a
 interfaceTypeDefinition (InterfaceTypeDefinition desc name dirs fieldDefinitions _possibleTypes) =
   -- `possibleTypes` are not included with an interface definition in a GraphQL IDL
-  "interface "
+  description desc
+  <> "interface "
   <> nameP name
   <> charP ' '
   <> optempty directives dirs
@@ -360,7 +369,8 @@ interfaceTypeDefinition (InterfaceTypeDefinition desc name dirs fieldDefinitions
 
 unionTypeDefinition :: Printer a => UnionTypeDefinition -> a
 unionTypeDefinition (UnionTypeDefinition desc name dirs members) =
-  "union "
+  description desc
+  <> "union "
   <> nameP name
   <> charP ' '
   <> optempty directives dirs
@@ -369,13 +379,15 @@ unionTypeDefinition (UnionTypeDefinition desc name dirs members) =
 
 enumValueDefinition :: Printer a => EnumValueDefinition -> a
 enumValueDefinition (EnumValueDefinition desc name dirs) =
-  (nameP $ unEnumValue name)
+  description desc
+  <> (nameP $ unEnumValue name)
   <> charP ' '
   <> optempty directives dirs
 
 enumTypeDefinition :: Printer a => EnumTypeDefinition -> a
 enumTypeDefinition (EnumTypeDefinition desc name dirs enumValDefns) =
-  "enum "
+  description desc
+  <> "enum "
   <> nameP name
   <> optempty directives dirs
   <> " {"
@@ -384,7 +396,8 @@ enumTypeDefinition (EnumTypeDefinition desc name dirs enumValDefns) =
 
 inputObjectTypeDefinition :: Printer a => InputObjectTypeDefinition InputValueDefinition -> a
 inputObjectTypeDefinition (InputObjectTypeDefinition desc name dirs valDefns) =
-  "input "
+  description desc
+  <> "input "
   <> nameP name
   <> optempty directives dirs
   <> " {"

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -386,7 +386,7 @@ data TypeDefinition a possibleTypes
   | TypeDefinitionInterface (InterfaceTypeDefinition a possibleTypes)
   | TypeDefinitionUnion UnionTypeDefinition
   | TypeDefinitionEnum EnumTypeDefinition
-  | TypeDefinitionInputObject InputObjectTypeDefinition
+  | TypeDefinitionInputObject (InputObjectTypeDefinition a)
   deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable a, Hashable possibleTypes) => Hashable (TypeDefinition a possibleTypes)
 
@@ -466,13 +466,13 @@ newtype EnumValue
   = EnumValue { unEnumValue :: Name }
   deriving (Show, Eq, Lift, Hashable, J.ToJSON, J.FromJSON, Ord)
 
-data InputObjectTypeDefinition = InputObjectTypeDefinition
+data InputObjectTypeDefinition a = InputObjectTypeDefinition
   { _iotdDescription      :: Maybe Description
   , _iotdName             :: Name
   , _iotdDirectives       :: [Directive Void]
-  , _iotdValueDefinitions :: [InputValueDefinition]
+  , _iotdValueDefinitions :: [a]
   } deriving (Ord, Show, Eq, Lift, Generic)
-instance Hashable InputObjectTypeDefinition
+instance (Hashable a) => Hashable (InputObjectTypeDefinition a)
 
 data DirectiveDefinition a = DirectiveDefinition
   { _ddDescription :: Maybe Description

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -216,7 +216,7 @@ instance J.FromJSON SchemaDocument where
 -- | A variant of 'SchemaDocument' that additionally stores, for each interface,
 -- the list of object types that implement that interface
 newtype SchemaIntrospection
-  = SchemaIntrospection [TypeDefinition InputValueDefinition [Name]]
+  = SchemaIntrospection [TypeDefinition [Name] InputValueDefinition]
   deriving (Ord, Show, Eq, Lift, Hashable, Generic)
 
 data OperationDefinition frag var

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -418,8 +418,8 @@ data InputValueDefinition = InputValueDefinition
   { _ivdDescription  :: Maybe Description
   , _ivdName         :: Name
   , _ivdType         :: GType
-  , _ivdDirectives   :: [Directive Void]
   , _ivdDefaultValue :: Maybe (Value Void)
+  , _ivdDirectives   :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable InputValueDefinition
 

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -418,6 +418,7 @@ data InputValueDefinition = InputValueDefinition
   { _ivdDescription  :: Maybe Description
   , _ivdName         :: Name
   , _ivdType         :: GType
+  , _ivdDirectives   :: [Directive Void]
   , _ivdDefaultValue :: Maybe (Value Void)
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable InputValueDefinition

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -387,7 +387,7 @@ data TypeDefinition possibleTypes
   | TypeDefinitionUnion UnionTypeDefinition
   | TypeDefinitionEnum EnumTypeDefinition
   | TypeDefinitionInputObject InputObjectTypeDefinition
-  deriving (Ord, Show, Eq, Lift, Generic)
+  deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance Hashable possibleTypes => Hashable (TypeDefinition possibleTypes)
 
 newtype Description
@@ -428,7 +428,7 @@ data InterfaceTypeDefinition possibleTypes = InterfaceTypeDefinition
   , _itdDirectives       :: [Directive Void]
   , _itdFieldsDefinition :: [FieldDefinition]
   , _itdPossibleTypes    :: possibleTypes
-  } deriving (Ord, Show, Eq, Lift, Generic)
+  } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance Hashable possibleTypes => Hashable (InterfaceTypeDefinition possibleTypes)
 
 data UnionTypeDefinition = UnionTypeDefinition

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -380,39 +380,39 @@ isNotNull = not . isNullable
 
 -- * Type definition
 
-data TypeDefinition possibleTypes a
+data TypeDefinition possibleTypes inputType
   = TypeDefinitionScalar ScalarTypeDefinition
-  | TypeDefinitionObject (ObjectTypeDefinition a)
-  | TypeDefinitionInterface (InterfaceTypeDefinition possibleTypes a)
+  | TypeDefinitionObject (ObjectTypeDefinition inputType)
+  | TypeDefinitionInterface (InterfaceTypeDefinition possibleTypes inputType)
   | TypeDefinitionUnion UnionTypeDefinition
   | TypeDefinitionEnum EnumTypeDefinition
-  | TypeDefinitionInputObject (InputObjectTypeDefinition a)
+  | TypeDefinitionInputObject (InputObjectTypeDefinition inputType)
   deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable a, Hashable possibleTypes) => Hashable (TypeDefinition a possibleTypes)
+instance (Hashable possibleTypes, Hashable inputType) => Hashable (TypeDefinition possibleTypes inputType)
 
 newtype Description
   = Description { unDescription :: Text }
   deriving (Show, Eq, Ord, IsString, Lift, Semigroup, Monoid, Hashable, J.ToJSON, J.FromJSON)
 
-data ObjectTypeDefinition a = ObjectTypeDefinition
+data ObjectTypeDefinition inputType = ObjectTypeDefinition
   { _otdDescription          :: Maybe Description
   , _otdName                 :: Name
   , _otdImplementsInterfaces :: [Name]
   , _otdDirectives           :: [Directive Void]
-  , _otdFieldsDefinition     :: [FieldDefinition a]
+  , _otdFieldsDefinition     :: [FieldDefinition inputType]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable a) => Hashable (ObjectTypeDefinition a)
+instance (Hashable inputType) => Hashable (ObjectTypeDefinition inputType)
 
-data FieldDefinition a = FieldDefinition
+data FieldDefinition inputType = FieldDefinition
   { _fldDescription         :: Maybe Description
   , _fldName                :: Name
-  , _fldArgumentsDefinition :: (ArgumentsDefinition a)
+  , _fldArgumentsDefinition :: (ArgumentsDefinition inputType)
   , _fldType                :: GType
   , _fldDirectives          :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable a) => Hashable (FieldDefinition a)
+instance (Hashable inputType) => Hashable (FieldDefinition inputType)
 
-type ArgumentsDefinition a = [a]
+type ArgumentsDefinition inputType = [inputType]
 
 data InputValueDefinition = InputValueDefinition
   { _ivdDescription  :: Maybe Description
@@ -423,14 +423,14 @@ data InputValueDefinition = InputValueDefinition
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable InputValueDefinition
 
-data InterfaceTypeDefinition possibleTypes a = InterfaceTypeDefinition
+data InterfaceTypeDefinition possibleTypes inputType = InterfaceTypeDefinition
   { _itdDescription      :: Maybe Description
   , _itdName             :: Name
   , _itdDirectives       :: [Directive Void]
-  , _itdFieldsDefinition :: [FieldDefinition a]
+  , _itdFieldsDefinition :: [FieldDefinition inputType]
   , _itdPossibleTypes    :: possibleTypes
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable a, Hashable possibleTypes) => Hashable (InterfaceTypeDefinition possibleTypes a)
+instance (Hashable possibleTypes, Hashable inputType) => Hashable (InterfaceTypeDefinition possibleTypes inputType)
 
 data UnionTypeDefinition = UnionTypeDefinition
   { _utdDescription :: Maybe Description
@@ -466,21 +466,21 @@ newtype EnumValue
   = EnumValue { unEnumValue :: Name }
   deriving (Show, Eq, Lift, Hashable, J.ToJSON, J.FromJSON, Ord)
 
-data InputObjectTypeDefinition a = InputObjectTypeDefinition
+data InputObjectTypeDefinition inputType = InputObjectTypeDefinition
   { _iotdDescription      :: Maybe Description
   , _iotdName             :: Name
   , _iotdDirectives       :: [Directive Void]
-  , _iotdValueDefinitions :: [a]
+  , _iotdValueDefinitions :: [inputType]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable a) => Hashable (InputObjectTypeDefinition a)
+instance (Hashable inputType) => Hashable (InputObjectTypeDefinition inputType)
 
-data DirectiveDefinition a = DirectiveDefinition
+data DirectiveDefinition inputType = DirectiveDefinition
   { _ddDescription :: Maybe Description
   , _ddName        :: Name
-  , _ddArguments   :: (ArgumentsDefinition a)
+  , _ddArguments   :: (ArgumentsDefinition inputType)
   , _ddLocations   :: [DirectiveLocation]
   } deriving (Ord, Show, Eq, Lift, Generic)
-instance (Hashable a) => Hashable (DirectiveDefinition a)
+instance (Hashable inputType) => Hashable (DirectiveDefinition inputType)
 
 data DirectiveLocation
   = DLExecutable ExecutableDirectiveLocation

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -471,7 +471,7 @@ data InputObjectTypeDefinition a = InputObjectTypeDefinition
   , _iotdName             :: Name
   , _iotdDirectives       :: [Directive Void]
   , _iotdValueDefinitions :: [a]
-  } deriving (Ord, Show, Eq, Lift, Generic)
+  } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable a) => Hashable (InputObjectTypeDefinition a)
 
 data DirectiveDefinition a = DirectiveDefinition

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -179,7 +179,7 @@ partitionExDefs = foldr f ([], [], [])
 
 data TypeSystemDefinition
   = TypeSystemDefinitionSchema SchemaDefinition
-  | TypeSystemDefinitionType (TypeDefinition InputValueDefinition ())  -- No 'possibleTypes' specified for interfaces
+  | TypeSystemDefinitionType (TypeDefinition () InputValueDefinition)  -- No 'possibleTypes' specified for interfaces
   deriving (Ord, Show, Eq, Lift, Generic)
 
 instance Hashable TypeSystemDefinition
@@ -380,10 +380,10 @@ isNotNull = not . isNullable
 
 -- * Type definition
 
-data TypeDefinition a possibleTypes
+data TypeDefinition possibleTypes a
   = TypeDefinitionScalar ScalarTypeDefinition
   | TypeDefinitionObject (ObjectTypeDefinition a)
-  | TypeDefinitionInterface (InterfaceTypeDefinition a possibleTypes)
+  | TypeDefinitionInterface (InterfaceTypeDefinition possibleTypes a)
   | TypeDefinitionUnion UnionTypeDefinition
   | TypeDefinitionEnum EnumTypeDefinition
   | TypeDefinitionInputObject (InputObjectTypeDefinition a)
@@ -400,7 +400,7 @@ data ObjectTypeDefinition a = ObjectTypeDefinition
   , _otdImplementsInterfaces :: [Name]
   , _otdDirectives           :: [Directive Void]
   , _otdFieldsDefinition     :: [FieldDefinition a]
-  } deriving (Ord, Show, Eq, Lift, Generic)
+  } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable a) => Hashable (ObjectTypeDefinition a)
 
 data FieldDefinition a = FieldDefinition
@@ -409,7 +409,7 @@ data FieldDefinition a = FieldDefinition
   , _fldArgumentsDefinition :: (ArgumentsDefinition a)
   , _fldType                :: GType
   , _fldDirectives          :: [Directive Void]
-  } deriving (Ord, Show, Eq, Lift, Generic)
+  } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable a) => Hashable (FieldDefinition a)
 
 type ArgumentsDefinition a = [a]
@@ -423,14 +423,14 @@ data InputValueDefinition = InputValueDefinition
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable InputValueDefinition
 
-data InterfaceTypeDefinition a possibleTypes = InterfaceTypeDefinition
+data InterfaceTypeDefinition possibleTypes a = InterfaceTypeDefinition
   { _itdDescription      :: Maybe Description
   , _itdName             :: Name
   , _itdDirectives       :: [Directive Void]
   , _itdFieldsDefinition :: [FieldDefinition a]
   , _itdPossibleTypes    :: possibleTypes
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
-instance (Hashable possibleTypes, Hashable a) => Hashable (InterfaceTypeDefinition a possibleTypes)
+instance (Hashable a, Hashable possibleTypes) => Hashable (InterfaceTypeDefinition possibleTypes a)
 
 data UnionTypeDefinition = UnionTypeDefinition
   { _utdDescription :: Maybe Description

--- a/src/Language/GraphQL/Draft/Syntax.hs-boot
+++ b/src/Language/GraphQL/Draft/Syntax.hs-boot
@@ -11,3 +11,4 @@ data TypedOperationDefinition (frag :: Type -> Type) var
 type role Selection representational nominal
 data Selection (frag :: Type -> Type) var
 type SelectionSet frag var = [Selection frag var]
+data SchemaDocument


### PR DESCRIPTION
This PR modifies some of the type definitions to be parametrisable, so that it easily works with the [remote schema permissions PR](https://github.com/hasura/graphql-engine/pull/6079). 

This PR also adds support for parsing the `schema` definition.

This PR does the following things:

1. modifies `ObjectTypeDefinition`, `InputObjectTypeDefinition` and `InterfaceTypeDefinition` to be parametrisable on the type of input value it accepts.
2. support parsing of the [GraphQL schema definition](https://spec.graphql.org/June2018/#sec-Schema)
3. add `Printer` instance for the `SchemaDocument`
