### PR TITLE
Allow fragments to use variables

### DIFF
--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -284,8 +284,8 @@ instance (Hashable (frag var), Hashable var) => Hashable (InlineFragment frag va
 data FragmentDefinition = FragmentDefinition
   { _fdName          :: Name
   , _fdTypeCondition :: Name
-  , _fdDirectives    :: [Directive Void]
-  , _fdSelectionSet  :: SelectionSet FragmentSpread Void
+  , _fdDirectives    :: [Directive Name]
+  , _fdSelectionSet  :: SelectionSet FragmentSpread Name
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable FragmentDefinition
 


### PR DESCRIPTION
Required for PR 225 on the internal repo, fixes hasura/graphql-engine#6303.