### PR TITLE
Add NFData instances

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -39,6 +39,7 @@ library
     , attoparsec
     , bytestring
     , containers
+    , deepseq
     , filepath
     , hedgehog
     , prettyprinter

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -78,33 +78,36 @@ module Language.GraphQL.Draft.Syntax (
   , fmapInlineFragment
   ) where
 
-import qualified Data.Aeson                     as J
-import qualified Data.Char                      as C
-import qualified Data.HashMap.Strict            as M
-import qualified Data.Text                      as T
-import qualified Language.Haskell.TH.Syntax     as TH
+import                qualified Data.Aeson                     as J
+import                qualified Data.Char                      as C
+import                qualified Data.HashMap.Strict            as M
+import                qualified Data.Text                      as T
+import                qualified Language.Haskell.TH.Syntax     as TH
 
-import           Control.Monad
-import           Data.Bool                      (bool)
-import           Data.Hashable
-import           Data.HashMap.Strict            (HashMap)
-import           Data.Scientific
-import           Data.String                    (IsString (..))
-import           Data.Text                      (Text)
-import           Data.Text.Prettyprint.Doc      (Pretty (..))
-import           Data.Void
-import           GHC.Generics                   (Generic)
-import           Instances.TH.Lift              ()
-import           Language.Haskell.TH.Syntax     (Lift, Q)
+import                          Control.DeepSeq
+import                          Control.Monad
+import                          Data.Bool                      (bool)
+import                          Data.HashMap.Strict            (HashMap)
+import                          Data.Hashable
+import                          Data.Scientific
+import                          Data.String                    (IsString (..))
+import                          Data.Text                      (Text)
+import                          Data.Text.Prettyprint.Doc      (Pretty (..))
+import                          Data.Void
+import                          GHC.Generics                   (Generic)
+import                          Instances.TH.Lift              ()
+import                          Language.Haskell.TH.Syntax     (Lift, Q)
 
-import {-# SOURCE #-} Language.GraphQL.Draft.Parser  (parseExecutableDoc, parseSchemaDocument)
-import {-# SOURCE #-} Language.GraphQL.Draft.Printer (renderExecutableDoc)
+import {-# SOURCE #-}           Language.GraphQL.Draft.Parser  (parseExecutableDoc,
+                                                                parseSchemaDocument)
+import {-# SOURCE #-}           Language.GraphQL.Draft.Printer (renderExecutableDoc)
+
 
 newtype Name = Name { unName :: Text }
-  deriving (Eq, Ord, Show, Hashable, Lift, Semigroup, J.ToJSONKey, J.ToJSON)
+  deriving (Eq, Ord, Show, Hashable, NFData, Lift, Semigroup, J.ToJSONKey, J.ToJSON)
 
 instance Pretty Name where
-  pretty = pretty. unName
+  pretty = pretty . unName
 
 mkName :: Text -> Maybe Name
 mkName text = T.uncons text >>= \(first, body) ->
@@ -145,7 +148,7 @@ instance Hashable Definition
 
 newtype ExecutableDocument var
   = ExecutableDocument { getExecutableDefinitions :: [ExecutableDefinition var] }
-  deriving (Ord, Show, Eq, Lift, Hashable, Functor, Foldable, Traversable)
+  deriving (Ord, Show, Eq, Lift, Hashable, NFData, Functor, Foldable, Traversable)
 
 instance J.FromJSON (ExecutableDocument Name) where
   parseJSON = J.withText "ExecutableDocument" $ \t ->
@@ -161,6 +164,7 @@ data ExecutableDefinition var
   | ExecutableDefinitionFragment FragmentDefinition
   deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance Hashable var => Hashable (ExecutableDefinition var)
+instance NFData   var => NFData   (ExecutableDefinition var)
 
 partitionExDefs
   :: [ExecutableDefinition var]
@@ -183,18 +187,21 @@ data TypeSystemDefinition
   deriving (Ord, Show, Eq, Lift, Generic)
 
 instance Hashable TypeSystemDefinition
+instance NFData   TypeSystemDefinition
 
 data SchemaDefinition = SchemaDefinition
   { _sdDirectives                   :: Maybe [Directive Void]
   , _sdRootOperationTypeDefinitions :: [RootOperationTypeDefinition]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable SchemaDefinition
+instance NFData   SchemaDefinition
 
 data RootOperationTypeDefinition = RootOperationTypeDefinition
   { _rotdOperationType     :: OperationType
   , _rotdOperationTypeType :: Name
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable RootOperationTypeDefinition
+instance NFData   RootOperationTypeDefinition
 
 data OperationType
   = OperationTypeQuery
@@ -202,16 +209,17 @@ data OperationType
   | OperationTypeSubscription
   deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable OperationType
+instance NFData   OperationType
 
 newtype SchemaDocument
   = SchemaDocument [TypeSystemDefinition]
-  deriving (Ord, Show, Eq, Lift, Hashable, Generic)
+  deriving (Ord, Show, Eq, Lift, Hashable, NFData, Generic)
 
 instance J.FromJSON SchemaDocument where
   parseJSON = J.withText "SchemaDocument" $ \t ->
     case parseSchemaDocument t of
       Right schemaDoc -> return schemaDoc
-      Left err -> fail $ "parsing the schema document: " <> show err
+      Left err        -> fail $ "parsing the schema document: " <> show err
 
 -- | A variant of 'SchemaDocument' that additionally stores, for each interface,
 -- the list of object types that implement that interface
@@ -224,6 +232,7 @@ data OperationDefinition frag var
   | OperationDefinitionUnTyped (SelectionSet frag var)
   deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance (Hashable (frag var), Hashable var) => Hashable (OperationDefinition frag var)
+instance (NFData   (frag var), NFData   var) => NFData   (OperationDefinition frag var)
 
 data TypedOperationDefinition frag var = TypedOperationDefinition
   { _todType                :: OperationType
@@ -233,6 +242,7 @@ data TypedOperationDefinition frag var = TypedOperationDefinition
   , _todSelectionSet        :: SelectionSet frag var
   } deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance (Hashable (frag var), Hashable var) => Hashable (TypedOperationDefinition frag var)
+instance (NFData   (frag var), NFData   var) => NFData  (TypedOperationDefinition frag var)
 
 data VariableDefinition = VariableDefinition
   { _vdName         :: Name
@@ -240,6 +250,7 @@ data VariableDefinition = VariableDefinition
   , _vdDefaultValue :: Maybe (Value Void)
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable VariableDefinition
+instance NFData   VariableDefinition
 
 type SelectionSet frag var = [Selection frag var]
 
@@ -249,6 +260,7 @@ data Selection frag var
   | SelectionInlineFragment (InlineFragment frag var)
   deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance (Hashable (frag var), Hashable var) => Hashable (Selection frag var)
+instance (NFData   (frag var), NFData   var) => NFData   (Selection frag var)
 
 data Field frag var = Field
   { _fAlias        :: Maybe Name
@@ -258,6 +270,7 @@ data Field frag var = Field
   , _fSelectionSet :: SelectionSet frag var
   } deriving (Ord, Show, Eq, Functor, Foldable, Traversable, Generic)
 instance (Hashable (frag var), Hashable var) => Hashable (Field frag var)
+instance (NFData   (frag var), NFData   var) => NFData   (Field frag var)
 instance (Lift (frag var), Lift var) => Lift (Field frag var) where
   liftTyped Field{..} =
     [|| Field { _fAlias, _fName, _fDirectives, _fSelectionSet
@@ -270,6 +283,7 @@ data FragmentSpread var = FragmentSpread
   , _fsDirectives :: [Directive var]
   } deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance Hashable var => Hashable (FragmentSpread var)
+instance NFData   var => NFData   (FragmentSpread var)
 
 -- | Can be used in place of the @frag@ parameter to various AST types to
 -- guarante that the AST does not include any fragment spreads.
@@ -279,6 +293,7 @@ instance Hashable var => Hashable (FragmentSpread var)
 data NoFragments var
   deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Lift, Generic)
 instance Hashable (NoFragments var)
+instance NFData   (NoFragments var)
 
 data InlineFragment frag var = InlineFragment
   { _ifTypeCondition :: Maybe Name
@@ -286,6 +301,7 @@ data InlineFragment frag var = InlineFragment
   , _ifSelectionSet  :: SelectionSet frag var
   } deriving (Ord, Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
 instance (Hashable (frag var), Hashable var) => Hashable (InlineFragment frag var)
+instance (NFData   (frag var), NFData   var) => NFData   (InlineFragment frag var)
 
 data FragmentDefinition = FragmentDefinition
   { _fdName          :: Name
@@ -294,6 +310,7 @@ data FragmentDefinition = FragmentDefinition
   , _fdSelectionSet  :: SelectionSet FragmentSpread Name
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable FragmentDefinition
+instance NFData   FragmentDefinition
 
 -- * Values
 
@@ -309,6 +326,7 @@ data Value var
   | VObject (HashMap Name (Value var))
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 instance Hashable var => Hashable (Value var)
+instance NFData   var => NFData   (Value var)
 instance Lift var => Lift (Value var) where
   liftTyped (VVariable a) = [|| VVariable a ||]
   liftTyped VNull         = [|| VNull ||]
@@ -330,6 +348,7 @@ data Directive var = Directive
   , _dArguments :: HashMap Name (Value var)
   } deriving (Ord, Show, Eq, Functor, Foldable, Traversable, Generic)
 instance Hashable var => Hashable (Directive var)
+instance NFData   var => NFData   (Directive var)
 instance Lift var => Lift (Directive var) where
   liftTyped Directive{..} = [|| Directive{ _dName, _dArguments = $$(liftTypedHashMap _dArguments) } ||]
 
@@ -337,7 +356,7 @@ instance Lift var => Lift (Directive var) where
 
 newtype Nullability
   = Nullability { unNullability :: Bool }
-  deriving (Show, Ord, Eq, Lift, Generic, Hashable)
+  deriving (Show, Ord, Eq, Lift, Generic, Hashable, NFData)
 
 data GType
   = TypeNamed Nullability Name
@@ -347,12 +366,13 @@ data GType
 getBaseType :: GType -> Name
 getBaseType = \case
   TypeNamed _ namedType -> namedType
-  TypeList _ listType -> getBaseType listType
+  TypeList _ listType   -> getBaseType listType
 
 instance J.ToJSON GType where
   toJSON = J.toJSON . showGT
 
 instance Hashable GType
+instance NFData   GType
 
 showGT :: GType -> Text
 showGT = \case
@@ -389,10 +409,11 @@ data TypeDefinition possibleTypes inputType
   | TypeDefinitionInputObject (InputObjectTypeDefinition inputType)
   deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable possibleTypes, Hashable inputType) => Hashable (TypeDefinition possibleTypes inputType)
+instance (NFData   possibleTypes, NFData   inputType) => NFData   (TypeDefinition possibleTypes inputType)
 
 newtype Description
   = Description { unDescription :: Text }
-  deriving (Show, Eq, Ord, IsString, Lift, Semigroup, Monoid, Hashable, J.ToJSON, J.FromJSON)
+  deriving (Show, Eq, Ord, IsString, Lift, Semigroup, Monoid, Hashable, NFData, J.ToJSON, J.FromJSON)
 
 data ObjectTypeDefinition inputType = ObjectTypeDefinition
   { _otdDescription          :: Maybe Description
@@ -402,6 +423,7 @@ data ObjectTypeDefinition inputType = ObjectTypeDefinition
   , _otdFieldsDefinition     :: [FieldDefinition inputType]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable inputType) => Hashable (ObjectTypeDefinition inputType)
+instance (NFData   inputType) => NFData   (ObjectTypeDefinition inputType)
 
 data FieldDefinition inputType = FieldDefinition
   { _fldDescription         :: Maybe Description
@@ -411,6 +433,7 @@ data FieldDefinition inputType = FieldDefinition
   , _fldDirectives          :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable inputType) => Hashable (FieldDefinition inputType)
+instance (NFData   inputType) => NFData   (FieldDefinition inputType)
 
 type ArgumentsDefinition inputType = [inputType]
 
@@ -422,6 +445,7 @@ data InputValueDefinition = InputValueDefinition
   , _ivdDirectives   :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable InputValueDefinition
+instance NFData   InputValueDefinition
 
 data InterfaceTypeDefinition possibleTypes inputType = InterfaceTypeDefinition
   { _itdDescription      :: Maybe Description
@@ -431,6 +455,7 @@ data InterfaceTypeDefinition possibleTypes inputType = InterfaceTypeDefinition
   , _itdPossibleTypes    :: possibleTypes
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable possibleTypes, Hashable inputType) => Hashable (InterfaceTypeDefinition possibleTypes inputType)
+instance (NFData   possibleTypes, NFData   inputType) => NFData   (InterfaceTypeDefinition possibleTypes inputType)
 
 data UnionTypeDefinition = UnionTypeDefinition
   { _utdDescription :: Maybe Description
@@ -439,6 +464,7 @@ data UnionTypeDefinition = UnionTypeDefinition
   , _utdMemberTypes :: [Name]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable UnionTypeDefinition
+instance NFData   UnionTypeDefinition
 
 data ScalarTypeDefinition = ScalarTypeDefinition
   { _stdDescription :: Maybe Description
@@ -446,6 +472,7 @@ data ScalarTypeDefinition = ScalarTypeDefinition
   , _stdDirectives  :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable ScalarTypeDefinition
+instance NFData   ScalarTypeDefinition
 
 data EnumTypeDefinition = EnumTypeDefinition
   { _etdDescription      :: Maybe Description
@@ -454,6 +481,7 @@ data EnumTypeDefinition = EnumTypeDefinition
   , _etdValueDefinitions :: [EnumValueDefinition]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable EnumTypeDefinition
+instance NFData   EnumTypeDefinition
 
 data EnumValueDefinition = EnumValueDefinition
   { _evdDescription :: Maybe Description
@@ -461,10 +489,11 @@ data EnumValueDefinition = EnumValueDefinition
   , _evdDirectives  :: [Directive Void]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable EnumValueDefinition
+instance NFData   EnumValueDefinition
 
 newtype EnumValue
   = EnumValue { unEnumValue :: Name }
-  deriving (Show, Eq, Lift, Hashable, J.ToJSON, J.FromJSON, Ord)
+  deriving (Show, Eq, Lift, Hashable, NFData, J.ToJSON, J.FromJSON, Ord)
 
 data InputObjectTypeDefinition inputType = InputObjectTypeDefinition
   { _iotdDescription      :: Maybe Description
@@ -473,6 +502,7 @@ data InputObjectTypeDefinition inputType = InputObjectTypeDefinition
   , _iotdValueDefinitions :: [inputType]
   } deriving (Ord, Show, Eq, Lift, Generic, Functor)
 instance (Hashable inputType) => Hashable (InputObjectTypeDefinition inputType)
+instance (NFData   inputType) => NFData   (InputObjectTypeDefinition inputType)
 
 data DirectiveDefinition inputType = DirectiveDefinition
   { _ddDescription :: Maybe Description
@@ -481,12 +511,14 @@ data DirectiveDefinition inputType = DirectiveDefinition
   , _ddLocations   :: [DirectiveLocation]
   } deriving (Ord, Show, Eq, Lift, Generic)
 instance (Hashable inputType) => Hashable (DirectiveDefinition inputType)
+instance (NFData   inputType) => NFData   (DirectiveDefinition inputType)
 
 data DirectiveLocation
   = DLExecutable ExecutableDirectiveLocation
   | DLTypeSystem TypeSystemDirectiveLocation
   deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable DirectiveLocation
+instance NFData   DirectiveLocation
 
 data ExecutableDirectiveLocation
   = EDLQUERY
@@ -498,6 +530,7 @@ data ExecutableDirectiveLocation
   | EDLINLINE_FRAGMENT
   deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable ExecutableDirectiveLocation
+instance NFData   ExecutableDirectiveLocation
 
 data TypeSystemDirectiveLocation
   = TSDLSCHEMA
@@ -513,6 +546,7 @@ data TypeSystemDirectiveLocation
   | TSDLINPUT_FIELD_DEFINITION
   deriving (Ord, Show, Eq, Lift, Generic)
 instance Hashable TypeSystemDirectiveLocation
+instance NFData   TypeSystemDirectiveLocation
 
 liftTypedHashMap :: (Eq k, Hashable k, Lift k, Lift v) => HashMap k v -> Q (TH.TExp (HashMap k v))
 liftTypedHashMap a = [|| M.fromList $$(TH.liftTyped $ M.toList a) ||]


### PR DESCRIPTION
We rely on those instances in the engine but define them as orphan instances in RQL.Instances instead.