### PR TITLE
fix parsing of interfaces list and prettify schema document printing

### DIFF
--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -312,7 +312,7 @@ objectTypeDefinition = AST.ObjectTypeDefinition
   <*> fieldDefinitions
 
 interfaces :: Parser [AST.Name]
-interfaces = tok "implements" *> many1 nameParser
+interfaces = tok "implements" *> nameParser `sepBy1` tok "&"
 
 fieldDefinitions :: Parser [(AST.FieldDefinition AST.InputValueDefinition)]
 fieldDefinitions = braces $ many1 fieldDefinition


### PR DESCRIPTION
- fixes parsing of the interfaces list when an object implements multiple interfaces 
- prettify the schema document's printer instance