### PR TITLE
Fix printer not properly encoding string values.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,8 @@ jobs:
           command: cabal new-build
       - run:
           name: Run tests
-          command: cabal new-test --test-options release
+          command: cabal run graphql-parser-test -- release
+          no_output_timeout: 20m
       - save_cache:
           name: Cache Dependencies
           key: cabal-store-v2-{{ checksum "cabal.project" }}-{{ checksum "graphql-parser.cabal" }}

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -204,11 +204,13 @@ stringLiteral = unescapeText =<< (char '"' *> jstring_ <?> "string")
     jstring_ :: Parser Text
     jstring_ = scan False go <* anyChar
 
-    go a c
-      | a = Just False
-      | c == '"' = Nothing
-      | otherwise = let a' = c == backslash
-                    in Just a'
+    go previousWasEscapingCharacter current
+      -- if the previous character was an escaping character, we skip this one
+      | previousWasEscapingCharacter = Just False
+      -- otherwise, if we find an unescaped quote, we've reached the end
+      | current == '"' = Nothing
+      -- otherwise, we continue, and track whether the current character is an escaping backslash
+      | otherwise = Just $ current == backslash
       where backslash = '\\'
 
     -- | Unescape a string.

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -2,6 +2,7 @@ module Language.GraphQL.Draft.Printer where
 
 import qualified Data.HashMap.Strict           as M
 
+import qualified Data.Aeson                    as J
 import           Data.Bool                     (bool)
 import           Data.HashMap.Strict           (HashMap)
 import           Data.List                     (intersperse, sort)
@@ -252,8 +253,9 @@ value = \case
   VObject o   -> objectValue o
   VEnum ev    -> nameP $ unEnumValue ev
 
+-- | We use Aeson to decode string values, and therefore use Aeson to encode them back.
 stringValue :: Printer a => Text -> a
-stringValue s = mconcat [ charP '"', textP s, charP '"' ]
+stringValue s = textP $ LT.toStrict $ LT.decodeUtf8 $ J.encode s
 
 listValue :: (Print var, Printer a) => [Value var] -> a
 listValue xs = mconcat [ charP '[' , li , charP ']' ]

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -4,29 +4,28 @@ import qualified Data.HashMap.Strict           as M
 
 import qualified Data.Aeson                    as J
 import           Data.Bool                     (bool)
+import qualified Data.ByteString.Builder       as BS
 import           Data.HashMap.Strict           (HashMap)
 import           Data.List                     (intersperse, sort)
 import           Data.Scientific
-import qualified Data.ByteString.Builder       as BS
-import qualified Data.Text.Lazy                as LT hiding (singleton)
-import qualified Data.Text.Lazy.Encoding       as LT
-import qualified Data.Text.Lazy.Builder        as LT
-import qualified Data.Text.Prettyprint.Doc     as PP
 import           Data.String                   (IsString)
 import           Data.Text                     (Text, pack)
-import qualified Text.Builder                  as Text
+import qualified Data.Text.Lazy                as LT hiding (singleton)
+import qualified Data.Text.Lazy.Builder        as LT
+import qualified Data.Text.Lazy.Encoding       as LT
+import qualified Data.Text.Prettyprint.Doc     as PP
 import           Data.Void
+import qualified Text.Builder                  as Text
 
 import           Language.GraphQL.Draft.Syntax
 
 class (Monoid a, IsString a) => Printer a where
-  stringP  :: String -> a
   textP    :: Text -> a
   charP    :: Char -> a
   intP     :: Integer -> a
   doubleP  :: Scientific -> a
 
-  {-# MINIMAL stringP, textP, charP, intP, doubleP #-}
+  {-# MINIMAL textP, charP, intP, doubleP #-}
 
   nameP    :: Name -> a
   nameP    = textP . unName
@@ -38,9 +37,6 @@ class (Monoid a, IsString a) => Printer a where
   selectionSetP = selectionSet
 
 instance Printer BS.Builder where
-  stringP = BS.stringUtf8
-  {-# INLINE stringP #-}
-
   textP = LT.encodeUtf8Builder . LT.fromStrict
   {-# INLINE textP #-}
 
@@ -54,9 +50,6 @@ instance Printer BS.Builder where
   {-# INLINE doubleP #-}
 
 instance Printer LT.Builder where
-  stringP = LT.fromString
-  {-# INLINE stringP #-}
-
   textP   = LT.fromText
   {-# INLINE textP #-}
 
@@ -70,9 +63,6 @@ instance Printer LT.Builder where
   {-# INLINE doubleP #-}
 
 instance Printer (PP.Doc Text) where
-  stringP       = PP.pretty
-  {-# INLINE stringP #-}
-
   textP         = PP.pretty
   {-# INLINE textP #-}
 
@@ -89,9 +79,6 @@ instance Printer (PP.Doc Text) where
   {-# INLINE nameP #-}
 
 instance Printer Text.Builder where
-  stringP = Text.string
-  {-# INLINE stringP #-}
-
   textP   = Text.text
   {-# INLINE textP #-}
 
@@ -222,7 +209,7 @@ defaultValue :: Printer a => Value Void -> a
 defaultValue v = " = " <> value v
 
 description :: Printer a => Maybe Description -> a
-description Nothing = mempty
+description Nothing     = mempty
 description (Just desc) = (stringValue $ unDescription desc) <> " \n"
 -- | Type Reference
 

--- a/src/Language/GraphQL/Draft/Printer.hs-boot
+++ b/src/Language/GraphQL/Draft/Printer.hs-boot
@@ -10,13 +10,12 @@ import {-# SOURCE #-} Language.GraphQL.Draft.Syntax
 class Print a
 instance Print Name
 class (Monoid a, IsString a) => Printer a where
-  stringP  :: String -> a
   textP    :: Text -> a
   charP    :: Char -> a
   intP     :: Integer -> a
   doubleP  :: Scientific -> a
 
-  {-# MINIMAL stringP, textP, charP, intP, doubleP #-}
+  {-# MINIMAL textP, charP, intP, doubleP #-}
 
   nameP    :: Name -> a
   nameP    = textP . unName

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -5,9 +5,10 @@
 module Keywords (primitiveTests) where
 
 import           Data.String
-import           Data.Text                      (unpack)
+import           Data.Text                      (singleton, unpack)
 import           Data.Void
 import           Hedgehog
+import           Hedgehog.Gen                   (unicode)
 import           Text.Builder                   (Builder, run)
 
 import           Language.GraphQL.Draft.Parser
@@ -16,37 +17,43 @@ import           Language.GraphQL.Draft.Syntax
 import qualified Language.GraphQL.Draft.Printer as P
 
 
-primitiveTests :: IsString s => [(s, Property)]
-primitiveTests =
-  [ ("a \"null\" prefix doesn't prevent parsing a name", propNullNameName)
-  , ("a \"null\" prefix doesn't prevent parsing an enum name", propNullNameValue)
-  , ("a \"true\" prefix doesn't prevent parsing an enum name", propBoolNameValue)
-  , ("a string containing \\NUL is handled correctly", propHandleNulString)
-  , ("a string containing \\n is handled correctly", propHandleNewlineString)
-  , ("a string containing \\x0011 is handled correctly", propHandleControlString)
+primitiveTests :: IsString s => TestLimit -> [(s, Property)]
+primitiveTests n =
+  [ ("a \"null\" prefix doesn't prevent parsing a name", withTests 1 propNullNameName)
+  , ("a \"null\" prefix doesn't prevent parsing an enum name", withTests 1 propNullNameValue)
+  , ("a \"true\" prefix doesn't prevent parsing an enum name", withTests 1 propBoolNameValue)
+  , ("a string containing \\NUL is handled correctly", withTests 1 propHandleNulString)
+  , ("a string containing \\n is handled correctly", withTests 1 propHandleNewlineString)
+  , ("a string containing \\x0011 is handled correctly", withTests 1 propHandleControlString)
+  , ("all unicode characters are supported", withTests n propHandleUnicodeCharacters)
   ]
 
 
 propNullNameValue :: Property
-propNullNameValue = testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "nullColumn")]
+propNullNameValue = property $ testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "nullColumn")]
 
 propBoolNameValue :: Property
-propBoolNameValue = testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "trueColumn")]
+propBoolNameValue = property $ testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "trueColumn")]
 
 propNullNameName :: Property
-propNullNameName = testRoundTrip nameParser P.nameP $$(litName "nullColumntwo")
+propNullNameName = property $ testRoundTrip nameParser P.nameP $$(litName "nullColumntwo")
 
 propHandleNulString :: Property
-propHandleNulString = testRoundTripValue $ VString "\NUL"
+propHandleNulString = property $ testRoundTripValue $ VString "\NUL"
 
 propHandleNewlineString :: Property
-propHandleNewlineString = testRoundTripValue $ VString "\n"
+propHandleNewlineString = property $ testRoundTripValue $ VString "\n"
 
 propHandleControlString :: Property
-propHandleControlString = testRoundTripValue $ VString "\x0011"
+propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
+
+propHandleUnicodeCharacters :: Property
+propHandleUnicodeCharacters = property $ do
+  c <- forAll unicode
+  testRoundTripValue $ VString $ singleton c
 
 
-testRoundTripValue :: Value Void -> Property
+testRoundTripValue :: Value Void -> PropertyT IO ()
 testRoundTripValue = testRoundTrip value P.value
 
 testRoundTrip
@@ -54,9 +61,8 @@ testRoundTrip
   => Parser a
   -> (a -> Builder)
   -> a
-  -> Property
-testRoundTrip parser printer ast =
-  property $ either onError (ast ===) astRoundTrip
+  -> PropertyT IO ()
+testRoundTrip parser printer ast = either onError (ast ===) astRoundTrip
   where
     astRoundTrip = runParser parser printed
     printed      = run $ printer ast

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -4,11 +4,11 @@
 
 module Keywords (primitiveTests) where
 
+import           Data.Foldable                  (for_)
 import           Data.String
 import           Data.Text                      (singleton, unpack)
 import           Data.Void
 import           Hedgehog
-import           Hedgehog.Gen                   (unicode)
 import           Text.Builder                   (Builder, run)
 
 import           Language.GraphQL.Draft.Parser
@@ -17,15 +17,15 @@ import           Language.GraphQL.Draft.Syntax
 import qualified Language.GraphQL.Draft.Printer as P
 
 
-primitiveTests :: IsString s => TestLimit -> [(s, Property)]
-primitiveTests n =
+primitiveTests :: IsString s => [(s, Property)]
+primitiveTests =
   [ ("a \"null\" prefix doesn't prevent parsing a name", withTests 1 propNullNameName)
   , ("a \"null\" prefix doesn't prevent parsing an enum name", withTests 1 propNullNameValue)
   , ("a \"true\" prefix doesn't prevent parsing an enum name", withTests 1 propBoolNameValue)
   , ("a string containing \\NUL is handled correctly", withTests 1 propHandleNulString)
   , ("a string containing \\n is handled correctly", withTests 1 propHandleNewlineString)
   , ("a string containing \\x0011 is handled correctly", withTests 1 propHandleControlString)
-  , ("all unicode characters are supported", withTests n propHandleUnicodeCharacters)
+  , ("all unicode characters are supported", withTests 1 propHandleUnicodeCharacters)
   ]
 
 
@@ -48,8 +48,7 @@ propHandleControlString :: Property
 propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
 
 propHandleUnicodeCharacters :: Property
-propHandleUnicodeCharacters = property $ do
-  c <- forAll unicode
+propHandleUnicodeCharacters = property $ for_ [minBound..maxBound] \c ->
   testRoundTripValue $ VString $ singleton c
 
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ViewPatterns #-}
 
-import           Control.Monad                         (void)
+import           Control.Monad                         (unless)
 import           Control.Monad.IO.Class                (liftIO)
 import           Hedgehog
 import           System.Environment                    (getArgs)
+import           System.Exit                           (exitFailure)
 
 import qualified Data.ByteString.Builder               as BS
 import qualified Data.ByteString.Lazy                  as BL
@@ -42,7 +43,9 @@ main = do
       _         -> TMDev
 
 runTest :: TestLimit -> IO ()
-runTest = void . tests
+runTest limit = do
+  allGood <- tests limit
+  unless allGood exitFailure
 
 tests :: TestLimit -> IO Bool
 tests nTests =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ViewPatterns     #-}
 
 import           Control.Monad                         (unless)
-import           Data.Void                             (Void)
 import           Hedgehog
 import           System.Environment                    (getArgs)
 import           System.Exit                           (exitFailure)
@@ -54,7 +53,6 @@ tests nTests =
     , ("property [ parse (textBuilderPrint ast) == ast ]", propParserTextPrinter nTests)
     , ("property [ parse (lazyTextBuilderPrint ast) == ast ]", propParserLazyTextPrinter nTests)
     , ("property [ parse (bytestringBuilderPrint ast) == ast ]", propParserBSPrinter nTests)
-    , ("property [ trip value ]", propTripValue nTests)
     ]
     ++ Keywords.primitiveTests nTests
 
@@ -72,11 +70,6 @@ propParserLazyTextPrinter = mkPropParserPrinter $ TL.toStrict . TL.toLazyText . 
 
 propParserBSPrinter :: TestLimit -> Property
 propParserBSPrinter = mkPropParserPrinter $ bsToTxt . BS.toLazyByteString . Output.executableDocument
-
-propTripValue :: TestLimit -> Property
-propTripValue limit = withTests limit $ property $ do
-  someValue <- forAll $ genValueWith []
-  tripping someValue (TB.run . Output.value) (Input.runParser (Input.value @Void))
 
 mkPropParserPrinter :: (ExecutableDocument Name -> T.Text) -> (TestLimit -> Property)
 mkPropParserPrinter printer = \space ->

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -31,9 +31,9 @@ main :: IO ()
 main = do
   args <- getArgs
   case parseArgs args of
-    TMQuick   -> runTest 200
-    TMDev     -> runTest 1000
-    TMRelease -> runTest 10000
+    TMQuick   -> runTest 100
+    TMDev     -> runTest 500
+    TMRelease -> runTest 1000
   where
     parseArgs = foldr parseArg TMDev
     parseArg str _ = case str of
@@ -54,7 +54,7 @@ tests nTests =
     , ("property [ parse (lazyTextBuilderPrint ast) == ast ]", propParserLazyTextPrinter nTests)
     , ("property [ parse (bytestringBuilderPrint ast) == ast ]", propParserBSPrinter nTests)
     ]
-    ++ Keywords.primitiveTests nTests
+    ++ Keywords.primitiveTests
 
 propParserPrettyPrinter :: TestLimit -> Property
 propParserPrettyPrinter = mkPropParserPrinter $ prettyPrinter . Output.executableDocument

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -32,9 +32,9 @@ main :: IO ()
 main = do
   args <- getArgs
   case parseArgs args of
-    TMQuick   -> runTest 20
-    TMDev     -> runTest 100
-    TMRelease -> runTest 1000
+    TMQuick   -> runTest 200
+    TMDev     -> runTest 1000
+    TMRelease -> runTest 10000
   where
     parseArgs = foldr parseArg TMDev
     parseArg str _ = case str of
@@ -56,7 +56,7 @@ tests nTests =
     , ("property [ parse (bytestringBuilderPrint ast) == ast ]", propParserBSPrinter nTests)
     , ("property [ trip value ]", propTripValue nTests)
     ]
-    ++ Keywords.primitiveTests
+    ++ Keywords.primitiveTests nTests
 
 propParserPrettyPrinter :: TestLimit -> Property
 propParserPrettyPrinter = mkPropParserPrinter $ prettyPrinter . Output.executableDocument


### PR DESCRIPTION
When decoding string values, we defer to Aeson for the handling of escaped characters, such as `\u0011` or `\n`. However, when printing a string value, we did NOT escape those back. Horrifyingly, our round trip tests failed to detect it. I suspect the range of the `unicode` generator is too large, and doesn't often contain characters such as the one that were failing. Running the tests on a loop, I managed to see them fail randomly.

This PR simply uses Aeson encoding in the printer, and does a bit of cleaning.