### PR TITLE
Avoids using 'show' in the Printer where possible

### DIFF
--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -75,7 +75,10 @@ instance Printer (PP.Doc Text) where
   intP          = PP.pretty
   {-# INLINE intP #-}
 
-  doubleP       = PP.pretty . LT.toStrict . LT.toLazyText . LTBS.scientificBuilder
+  -- NOTE: @prettyprinter@ constructs its 'Int', 'Float', etc. instances with
+  -- 'unsafeViaShow', so it fine for us to use it here since 'Scientific'
+  -- satisfies the requirement that the 'Show' instance must not have newlines.
+  doubleP       = PP.unsafeViaShow
   {-# INLINE doubleP #-}
 
   nameP         = PP.pretty


### PR DESCRIPTION
tl;dr We depend on `show` in a few places where we don't strictly need to, as functions to construct the various `Builder`s (or construct `Text` via a `Bulider`, in the case of `Pretty`) exist.