### PR TITLE
Introducing block strings

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -64,6 +64,7 @@ test-suite graphql-parser-test
   main-is: Spec.hs
   other-modules:
     Keywords
+    BlockStrings
   build-depends:
     , base >=4.7 && <5
     , graphql-parser

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -115,13 +115,14 @@ genBlockText =
       , (5, genMinIndentedText 10)
       , (4, return "")
       , (3, return " ")
+      , (6, return "\t")
       , (3, return "\"") -- "
       , (3, return "\\") -- \
       ]
   genLines :: Gen Text
   genLines = do
-    n <- Gen.int (Range.linear 1 100)
-    x <- Gen.list (Range.linear 1 n) simple
+    n <- Gen.int (Range.linear 0 100)
+    x <- Gen.list (Range.linear 0 n) simple
     return (T.unlines x)
 
 -- | Like `genText` but with random indentation in the start of the string according
@@ -135,10 +136,10 @@ genMinIndentedText min_ = do
 
 genIndentation :: Gen Text
 genIndentation = do
-  n <- Gen.int (Range.linear 1 30)
+  n <- Gen.int (Range.linear 0 30)
   T.concat <$> Gen.choice
-    [ Gen.list (Range.linear 1 n) (return " ")
-    , Gen.list (Range.linear 1 (n * 100)) (return " ")
+    [ Gen.list (Range.linear 0 n) (return " ")
+    , Gen.list (Range.linear 0 (n * 100)) (return " ")
     ]
 
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -104,26 +104,25 @@ genObjectValue genVal = M.fromList <$> mkList genObjectField
     genObjectField = (,) <$> genName <*> genVal
 
 genBlockText :: Gen Text
-genBlockText =
-  Gen.choice [ simple, genLines ]
- where
-  simple = do
-    Gen.frequency
-      [ (10, Gen.text (Range.linear 1 100) Gen.unicode)
-      , (10, return "\n")
-      , (6, genIndentation)
-      , (5, genMinIndentedText 10)
-      , (4, return "")
-      , (3, return " ")
-      , (6, return "\t")
-      , (3, return "\"") -- "
-      , (3, return "\\") -- \
-      ]
-  genLines :: Gen Text
-  genLines = do
-    n <- Gen.int (Range.linear 0 100)
-    x <- Gen.list (Range.linear 0 n) simple
-    return (T.unlines x)
+genBlockText = Gen.choice [ simple, genLines ]
+  where
+    simple = do
+      Gen.frequency
+        [ (10, Gen.text (Range.linear 1 100) Gen.unicode)
+        , (10, return "\n")
+        , (6, genIndentation)
+        , (5, genMinIndentedText 10)
+        , (4, return "")
+        , (3, return " ")
+        , (6, return "\t")
+        , (3, return "\"") -- "
+        , (3, return "\\") -- \
+        ]
+    genLines :: Gen Text
+    genLines = do
+      n <- Gen.int (Range.linear 0 100)
+      x <- Gen.list (Range.linear 0 n) simple
+      return (T.unlines x)
 
 -- | Like `genText` but with random indentation in the start of the string according
 -- to a minimum value.
@@ -373,7 +372,6 @@ genDirectives = mkList genDirective
 
 genArgument :: Generator a => Gen (Name, Value a)
 genArgument = (,) <$> genName <*> genValue
-
 
 
 -- | *Helpers*

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -87,8 +87,8 @@ genValueWith varGens = Gen.recursive Gen.choice nonRecursive recursive
                    , VInt . fromIntegral <$> Gen.int32 (Range.linear 1 99999)
                    , VEnum <$> genEnumValue
                    , VFloat . fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
-                   , VString StringCharacter <$> genText
-                   , VString BlockStringCharacter <$> genBlockText
+                   , VString <$> genText
+                   , VString <$> genBlockText
                    , VBoolean <$> Gen.bool
                    ] <> [VVariable <$> var | var <- varGens]
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -88,7 +88,7 @@ genValueWith varGens = Gen.recursive Gen.choice nonRecursive recursive
                    , VEnum <$> genEnumValue
                    , VFloat . fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
                    , VString <$> genText
-                   , VString <$> genBlockText
+                   -- , VString <$> genBlockText
                    , VBoolean <$> Gen.bool
                    ] <> [VVariable <$> var | var <- varGens]
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -88,7 +88,7 @@ genValueWith varGens = Gen.recursive Gen.choice nonRecursive recursive
                    , VEnum <$> genEnumValue
                    , VFloat . fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
                    , VString <$> genText
-                   -- , VString <$> genBlockText
+                   , VString <$> genBlockText
                    , VBoolean <$> Gen.bool
                    ] <> [VVariable <$> var | var <- varGens]
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -7,9 +7,9 @@ import           Data.Void
 import           Hedgehog
 
 import qualified Data.HashMap.Strict           as M
+import qualified Data.Text                     as T
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
-import qualified Data.Text                     as T
 
 import           Language.GraphQL.Draft.Syntax
 
@@ -87,7 +87,7 @@ genValueWith varGens = Gen.recursive Gen.choice nonRecursive recursive
                    , VInt . fromIntegral <$> Gen.int32 (Range.linear 1 99999)
                    , VEnum <$> genEnumValue
                    , VFloat . fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
-                   , VString <$> genText
+                   , VString <$> Gen.choice [genText, genBlockText]
                    , VBoolean <$> Gen.bool
                    ] <> [VVariable <$> var | var <- varGens]
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -129,7 +129,7 @@ genMinIndentedText min_ = do
 
 genIndentation :: Gen Text
 genIndentation = do
-  Gen.text (Range.linear 0 100) (return " ")
+  Gen.text (Range.linear 0 100) (return ' ')
 
 
 -- | *Definitions*

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -88,7 +88,6 @@ genValueWith varGens = Gen.recursive Gen.choice nonRecursive recursive
                    , VEnum <$> genEnumValue
                    , VFloat . fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
                    , VString <$> genText
-                   , VString <$> genBlockText
                    , VBoolean <$> Gen.bool
                    ] <> [VVariable <$> var | var <- varGens]
 

--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -103,11 +103,11 @@ genObjectValue genVal = M.fromList <$> mkList genObjectField
     genObjectField = (,) <$> genName <*> genVal
 
 genBlockText :: Gen Text
-genBlockText = Gen.choice [ simple, genLines ]
+genBlockText = T.unlines <$> Gen.list (Range.linear 0 20) line
   where
-    simple = do
+    line = do
       Gen.frequency
-        [ (10, Gen.text (Range.linear 1 100) Gen.unicode)
+        [ (10, Gen.text (Range.linear 1 10) Gen.unicode)
         , (10, return "\n")
         , (6, genIndentation)
         , (5, genMinIndentedText 10)
@@ -117,11 +117,6 @@ genBlockText = Gen.choice [ simple, genLines ]
         , (3, return "\"") -- "
         , (3, return "\\") -- \
         ]
-    genLines :: Gen Text
-    genLines = do
-      n <- Gen.int (Range.linear 0 100)
-      x <- Gen.list (Range.linear 0 n) simple
-      return (T.unlines x)
 
 -- | Like `genText` but with random indentation in the start of the string according
 -- to a minimum value.
@@ -134,11 +129,7 @@ genMinIndentedText min_ = do
 
 genIndentation :: Gen Text
 genIndentation = do
-  n <- Gen.int (Range.linear 0 30)
-  T.concat <$> Gen.choice
-    [ Gen.list (Range.linear 0 n) (return " ")
-    , Gen.list (Range.linear 0 (n * 100)) (return " ")
-    ]
+  Gen.text (Range.linear 0 100) (return " ")
 
 
 -- | *Definitions*

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -41,7 +41,6 @@ import           Data.Functor
 import           Data.HashMap.Strict           (HashMap)
 import           Data.Scientific               (Scientific)
 import           Data.Text                     (Text, find)
-
 import           Data.Text.Lazy                (toStrict)
 import           Data.Void                     (Void)
 import           Data.Maybe                    (fromMaybe)

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -186,14 +186,14 @@ value :: Variable var => Parser (AST.Value var)
 value = tok (
       AST.VVariable    <$> variable
   <|> (fmap (either AST.VFloat AST.VInt) number <?> "number")
-  <|> AST.VNull        <$  literal "null"
-  <|> AST.VBoolean                         <$> booleanLiteral
-  <|> AST.VString AST.BlockStringCharacter <$> blockString
-  <|> AST.VString AST.StringCharacter      <$> stringLiteral
+  <|> AST.VNull    <$  literal "null"
+  <|> AST.VBoolean <$> booleanLiteral
+  <|> AST.VString  <$> blockString
+  <|> AST.VString  <$> stringLiteral
   -- `true` and `false` have been tried before, so we can safely proceed with the enum parser
-  <|> AST.VEnum                            <$> (fmap AST.EnumValue nameParser <?> "name")
-  <|> AST.VList                            <$> listLiteral
-  <|> AST.VObject                          <$> objectLiteral
+  <|> AST.VEnum    <$> (fmap AST.EnumValue nameParser <?> "name")
+  <|> AST.VList    <$> listLiteral
+  <|> AST.VObject  <$> objectLiteral
   <?> "value")
 
 booleanLiteral :: Parser Bool

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -184,14 +184,14 @@ value :: Variable var => Parser (AST.Value var)
 value = tok (
       AST.VVariable    <$> variable
   <|> (fmap (either AST.VFloat AST.VInt) number <?> "number")
-  <|> AST.VNull    <$  literal "null"
-  <|> AST.VBoolean <$> booleanLiteral
-  <|> AST.VString  <$> blockString
-  <|> AST.VString  <$> stringLiteral
+  <|> AST.VNull        <$  literal "null"
+  <|> AST.VBoolean     <$> booleanLiteral
+  <|> AST.VString      <$> blockString
+  <|> AST.VString      <$> stringLiteral
   -- `true` and `false` have been tried before, so we can safely proceed with the enum parser
-  <|> AST.VEnum    <$> (fmap AST.EnumValue nameParser <?> "name")
-  <|> AST.VList    <$> listLiteral
-  <|> AST.VObject  <$> objectLiteral
+  <|> AST.VEnum        <$> (fmap AST.EnumValue nameParser <?> "name")
+  <|> AST.VList        <$> listLiteral
+  <|> AST.VObject      <$> objectLiteral
   <?> "value")
 
 booleanLiteral :: Parser Bool
@@ -504,7 +504,7 @@ blockString = extractText <$> (tripleQuotes *> blockContents)
       -- this drop the parsed closing quotes (since we are using a different parser)
       (textBlock, Done) -> return $ T.lines (T.dropEnd 3 textBlock)
       -- there is only one way to get to a Done, so we need this here because runScanner never fails
-      _  -> fail "couldn't parse block string" 
+      _                 -> fail "couldn't parse block string"
 
     extractText = \case
       [] -> ""

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -495,6 +495,10 @@ blockString = do
   _ <- tripleQuotes <?> "opening triple quotes"
   lines_ <- T.lines . T.pack <$> AT.manyTill AT.anyChar tripleQuotes <?> "the body of a triple quoted string"
   let tail_ = drop 1 lines_
+  -- TODO the following line, as suggested didn't seem to
+  -- work on a first attemp
+  --let smallest = foldr min maxBound (countIndentation <$> tail_)
+  --let smallest = foldr min maxBound (countIndentation <$> tail_)
   let smallest = foldr selectSmallest maxBound tail_
   let fixedLines_ = foldr (fixIndentation smallest) Nothing tail_
   case fixedLines_ of
@@ -538,7 +542,6 @@ blockString = do
        then new
        else acc
 
-  -- used to count indentation in a single a line
   countIndentation :: Text -> Int
   countIndentation = fromMaybe 0 . T.findIndex (not . ws)
 

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -190,7 +190,8 @@ value = tok (
   <|> AST.VBoolean                         <$> booleanLiteral
   <|> AST.VString AST.BlockStringCharacter <$> blockString
   <|> AST.VString AST.StringCharacter      <$> stringLiteral
-  <|> AST.VEnum                            <$> (fmap AST.EnumValue nameParser <?> "name") -- `true` and `false` have been tried before
+  -- `true` and `false` have been tried before, so we can safely proceed with the enum parser
+  <|> AST.VEnum                            <$> (fmap AST.EnumValue nameParser <?> "name")
   <|> AST.VList                            <$> listLiteral
   <|> AST.VObject                          <$> objectLiteral
   <?> "value")

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -18,7 +18,6 @@ module Language.GraphQL.Draft.Parser
   , parseGraphQLType
 
   , Parser
-
   , runParser
   , blockString
   ) where

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -46,7 +46,6 @@ import           Data.Void                     (Void)
 import           Data.Maybe                    (fromMaybe)
 
 import qualified Language.GraphQL.Draft.Syntax as AST
-import Debug.Trace
 
 -- * Document
 

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -484,7 +484,6 @@ between open close p = tok open *> p <* tok close
 optempty :: Monoid a => Parser a -> Parser a
 optempty = option mempty
 
-
 data BlockState
   = Escaped Int 
   | Closing Int
@@ -497,7 +496,7 @@ blockString :: Parser Text
 blockString = do
   _ <- tripleQuotes <?> "opening triple quotes"
   lines_ <- AT.runScanner Normal scanner >>= \case
-    (lines_,Done) -> return (T.lines (T.dropEnd 3 lines_)) -- this drop the parsed closing quotes
+    (lines_,Done) -> return (T.lines (T.dropEnd 3 lines_)) -- this drop the parsed closing quotes (since we are using a different parser)
     (_,_)         -> fail "couldn't parse block string"
   let headline = if lines_ == [] then "" else head lines_
   let tail_ = drop 1 lines_ -- not tail
@@ -507,9 +506,9 @@ blockString = do
     Nothing -> headline
     Just reformatedLines -> rebuild (sanitize $ headline:reformatedLines)
  where
-  -- this function is used to parse the body of the string
+  -- | This function is used to parse the body of the string
   -- while counting stuff that we might need for escaping,
-  -- for example
+  -- for example.
   scanner :: BlockState -> Char -> Maybe BlockState
   scanner s ch = 
     case s of

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BangPatterns #-}
 
 -- | Description: Parse text into GraphQL ASTs
 module Language.GraphQL.Draft.Parser

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -495,11 +495,7 @@ blockString = do
   _ <- tripleQuotes <?> "opening triple quotes"
   lines_ <- T.lines . T.pack <$> AT.manyTill AT.anyChar tripleQuotes <?> "the body of a triple quoted string"
   let tail_ = drop 1 lines_
-  -- TODO the following line, as suggested didn't seem to
-  -- work on a first attemp
-  --let smallest = foldr min maxBound (countIndentation <$> tail_)
-  --let smallest = foldr min maxBound (countIndentation <$> tail_)
-  let smallest = foldr selectSmallest maxBound tail_
+  let smallest = foldr min maxBound (countIndentation <$> tail_)
   let fixedLines_ = foldr (fixIndentation smallest) Nothing tail_
   case fixedLines_ of
     Nothing -> 
@@ -534,16 +530,8 @@ blockString = do
       Nothing -> Just new
       Just acc -> Just $ new <> "\n" <> acc
 
-  -- used to accumulate the smallest indentation
-  selectSmallest :: Text -> Int -> Int
-  selectSmallest t acc =
-    let new = countIndentation t
-     in if (not $ T.all ws t) && new < acc
-       then new
-       else acc
-
   countIndentation :: Text -> Int
-  countIndentation = fromMaybe 0 . T.findIndex (not . ws)
+  countIndentation = fromMaybe maxBound . T.findIndex (not . ws)
 
   tripleQuotes = AT.string "\"\"\""
 

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -498,7 +498,7 @@ data BlockState
 -- | Parses strings delimited by triple quotes.
 -- http://spec.graphql.org/June2018/#sec-String-Value
 blockString :: Parser Text
-blockString = extractText <$> (tripleQuotes *> blockContents)
+blockString = extractText <$> ("\"\"\"" *> blockContents)
   where
     blockContents = AT.runScanner Continue scanner >>= \case
       -- this drop the parsed closing quotes (since we are using a different parser)
@@ -550,7 +550,6 @@ blockString = extractText <$> (tripleQuotes *> blockContents)
 
     countIndentation :: Text -> Int
     countIndentation = fromMaybe maxBound . T.findIndex (not . isWhitespace)
-    tripleQuotes = AT.string "\"\"\""
 
 -- whitespace
 isWhitespace :: Char -> Bool

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -508,7 +508,7 @@ blockString = extractText <$> ("\"\"\"" *> blockContents)
 
     extractText = 
       -- The reason we have this replace here is to convert
-      -- an escapped triple-quotes to the way it should be
+      -- an escaped triple-quotes to the way it should be
       -- represented in the parsed strings. The printer will
       -- deal with it normally.
       T.replace "\\\"\"\"" "\"\"\"" . \case

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -506,7 +506,7 @@ blockString = extractText <$> ("\"\"\"" *> blockContents)
       -- there is only one way to get to a Done, so we need this here because runScanner never fails
       _                 -> fail "couldn't parse block string"
 
-    extractText = \case
+    extractText = T.replace "\\\"\"\"" "\"\"\"" . \case
       [] -> ""
       -- we keep the first line apart as, per the specification, it should not count for
       -- the calculation of the common minimum indentation:

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -498,7 +498,7 @@ blockString = do
   _ <- tripleQuotes <?> "opening triple quotes"
   lines_ <- AT.runScanner Normal scanner >>= \case
     (lines_,Done) -> return (T.lines (T.dropEnd 3 lines_)) -- this drop the parsed closing quotes
-    (_,_)         -> fail "could'nt parse block string"
+    (_,_)         -> fail "couldn't parse block string"
   let headline = if lines_ == [] then "" else head lines_
   let tail_ = drop 1 lines_ -- not tail
   let commonIndentation = foldr min maxBound (countIndentation <$> tail_)

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -497,11 +497,9 @@ blockString = do
   let tail_ = drop 1 lines_
   let smallest = foldr min maxBound (countIndentation <$> tail_)
   let fixedLines_ = foldr (fixIndentation smallest) Nothing tail_
+  let xxx = if lines_ == [] then return "" else return $ head lines_
   case fixedLines_ of
-    Nothing -> 
-      if lines_ == []
-      then return ""
-      else return $ head lines_
+    Nothing -> return xxx -- TODO WIP
     Just fixedLines -> 
       if lines_ == []
       then do
@@ -513,6 +511,7 @@ blockString = do
 
  where
 
+  -- TODO these 2 are wrong
   sanitizeEnd t = 
     if T.null t
        then t

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -505,7 +505,7 @@ blockString = do
   sanitize :: [Text] -> [Text]
   sanitize = dropWhileEnd' onlyWhiteSpace  . dropWhile onlyWhiteSpace
   onlyWhiteSpace :: Text -> Bool
-  onlyWhiteSpace t = T.null t || T.all ws t
+  onlyWhiteSpace t = T.all ws t
   removeCommonIndentation :: Int -> Text -> Maybe [Text] -> Maybe [Text] 
   removeCommonIndentation smallest a x = 
     let new = T.drop smallest a

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -236,19 +236,23 @@ variableP v = charP '$' <> printP v
 
 value :: (Print var, Printer a) => Value var -> a
 value = \case
-  VVariable v -> variableP v
-  VInt i      -> intP i
-  VFloat d    -> doubleP d
-  VString s   -> stringValue s
-  VBoolean b  -> fromBool b
-  VNull       -> "null"
-  VList xs    -> listValue xs
-  VObject o   -> objectValue o
-  VEnum ev    -> nameP $ unEnumValue ev
+  VVariable v    -> variableP v
+  VInt i         -> intP i
+  VFloat d       -> doubleP d
+  VString s      -> stringValue s
+  VBlockString s -> blockStringValue s
+  VBoolean b     -> fromBool b
+  VNull          -> "null"
+  VList xs       -> listValue xs
+  VObject o      -> objectValue o
+  VEnum ev       -> nameP $ unEnumValue ev
 
 -- | We use Aeson to decode string values, and therefore use Aeson to encode them back.
 stringValue :: Printer a => Text -> a
 stringValue s = textP $ LT.toStrict $ LTE.decodeUtf8 $ J.encode s
+
+blockStringValue :: Printer a => Text -> a
+blockStringValue t = textP "\"\"\"\n" <> textP t <> textP "\n\"\"\""
 
 listValue :: (Print var, Printer a) => [Value var] -> a
 listValue xs = mconcat [ charP '[' , li , charP ']' ]

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -236,19 +236,17 @@ variableP v = charP '$' <> printP v
 
 value :: (Print var, Printer a) => Value var -> a
 value = \case
-  VVariable v    -> variableP v
-  VInt i         -> intP i
-  VFloat d       -> doubleP d
-  VString t s    -> dispatchStringPrinter t s
-  VBoolean b     -> fromBool b
-  VNull          -> "null"
-  VList xs       -> listValue xs
-  VObject o      -> objectValue o
-  VEnum ev       -> nameP $ unEnumValue ev
+  VVariable v -> variableP v
+  VInt i      -> intP i
+  VFloat d    -> doubleP d
+  VString s   -> dispatchStringPrinter s
+  VBoolean b  -> fromBool b
+  VNull       -> "null"
+  VList xs    -> listValue xs
+  VObject o   -> objectValue o
+  VEnum ev    -> nameP $ unEnumValue ev
 
-dispatchStringPrinter t s = case t of
-  StringCharacter -> stringValue s
-  BlockStringCharacter -> blockStringValue s
+dispatchStringPrinter s = undefined
 
 -- | We use Aeson to decode string values, and therefore use Aeson to encode them back.
 stringValue :: Printer a => Text -> a

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -250,7 +250,7 @@ value = \case
   VEnum ev    -> nameP $ unEnumValue ev
 
 data HasNonPrintable = NoNonPrintable | HasNonPrintable
-data AtLeastOneZeroIndent = AtLeastOneZeroIndent | NoZeroIdent
+data AtLeastOneZeroIndent = AtLeastOneZeroIndent | NoZeroIndent
 data BlockStatus
   = NormalString
   | KeepGoing !AtLeastOneZeroIndent !HasNonPrintable
@@ -263,7 +263,8 @@ dispatchStringPrinter t
   | T.null t = stringValue ""
   | not (T.null . T.takeWhile isWhitespace $ t) =  stringValue t
   | not (T.null . T.takeWhileEnd isWhitespace $ t) = stringValue t
-  | otherwise = handleResult $ foldr go (KeepGoing NoZeroIdent NoNonPrintable) (T.lines t)
+  | "\"\"\"" `T.isInfixOf` t = stringValue t
+  | otherwise = handleResult $ foldr go (KeepGoing NoZeroIndent NoNonPrintable) (T.lines t)
  where
   go a = \case
     NormalString  -> NormalString
@@ -277,7 +278,7 @@ dispatchStringPrinter t
   checkAtLeastOneZeroIndent AtLeastOneZeroIndent _ = AtLeastOneZeroIndent
   checkAtLeastOneZeroIndent _ str
     | T.null (T.takeWhile isWhitespace str) = AtLeastOneZeroIndent
-    | otherwise = NoZeroIdent
+    | otherwise = NoZeroIndent
 
   checkEscapedNewLines HasNonPrintable _ = HasNonPrintable
   checkEscapedNewLines NoNonPrintable str

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -249,46 +249,29 @@ value = \case
   VEnum ev    -> nameP $ unEnumValue ev
 
 data BlockStatus
-  = Starting
-  | NormalString
-  | KeepGoing
+  = NormalString
+  | KeepGoing    AtLeastOneZeroIndent HasEscapedNewlines
+type AtLeastOneZeroIndent = Bool; type HasEscapedNewlines = Bool
 
-data BlockState = BlockState
-  { atLeastOneZeroIndent :: Bool
-  , doNotStartWithNL     :: Bool
-  , hasEscapedNewLines   :: Bool
-  }
-
+-- | We us this function to decide how to print a string,
+-- which might be a normal string or a block string.
 dispatchStringPrinter :: Printer a => Text -> a
 dispatchStringPrinter t = 
   let ls = T.lines t
    in if T.null t 
       then stringValue ""
-      else if T.all isWhitespace (last ls)
+      else if T.all isWhitespace (last ls) || T.all isWhitespace (head ls)
            then stringValue t
-           else handleResult $ foldr go (Starting, BlockState False True False) ls
+           else handleResult $ foldr go (KeepGoing False False) ls
  where
-  go a acc = 
-    case acc of
-      (NormalString, s) -> (NormalString, s)
-      (Starting, s) -> 
-        if T.null a
-           then (NormalString, s { doNotStartWithNL = False })
-           else (KeepGoing, 
-                    s { atLeastOneZeroIndent = checkAtLeastOneZeroIndent (atLeastOneZeroIndent s) a
-                      , hasEscapedNewLines = checkEscapedNewLines (hasEscapedNewLines s) a
-                      })
-      (KeepGoing, s) -> 
-        (KeepGoing
-          , s { atLeastOneZeroIndent = checkAtLeastOneZeroIndent (atLeastOneZeroIndent s) a
-          , hasEscapedNewLines = checkEscapedNewLines (hasEscapedNewLines s) a
-          })
-  handleResult (_,s) = 
-    if not (atLeastOneZeroIndent s || hasEscapedNewLines s)
-       then stringValue t
-       else if doNotStartWithNL s
-          then blockStringValue t
-          else stringValue t
+  go a = \case
+    NormalString  -> NormalString
+    KeepGoing x y -> KeepGoing (checkAtLeastOneZeroIndent x a) (checkEscapedNewLines y a)
+  handleResult = \case
+    NormalString -> stringValue t
+    KeepGoing atLeastOneZeroIndent hasEscapedNewLines -> 
+      if atLeastOneZeroIndent || hasEscapedNewLines 
+         then blockStringValue t else stringValue t
 
   checkAtLeastOneZeroIndent p t = if p then p else T.null (T.takeWhile isWhitespace t)
   checkEscapedNewLines p t = if p then p else "\\n" `T.isInfixOf` t

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -21,7 +21,7 @@ import qualified Data.Text.Prettyprint.Doc          as PP
 import           Data.Void                          (Void, absurd)
 import qualified Text.Builder                       as Text
 
-import           Data.Char                          (isPrint)
+import           Data.Char                          (isControl)
 import           Language.GraphQL.Draft.Syntax
 
 
@@ -271,7 +271,7 @@ dispatchStringPrinter t =
     hasZeroIndentation = any lineZeroIndentation $ tail $ T.lines t
       where
         lineZeroIndentation line = case T.uncons line of
-          Nothing -> False -- empty lines don't count
+          Nothing            -> False -- empty lines don't count
           Just (firstChar,_) -> not (isWhitespace firstChar)
     -- Condition 5: although """ is printable in block strings as \""", this
     -- isn't currently implemented

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -239,13 +239,16 @@ value = \case
   VVariable v    -> variableP v
   VInt i         -> intP i
   VFloat d       -> doubleP d
-  VString s      -> stringValue s
-  VBlockString s -> blockStringValue s
+  VString t s    -> dispatchStringPrinter t s
   VBoolean b     -> fromBool b
   VNull          -> "null"
   VList xs       -> listValue xs
   VObject o      -> objectValue o
   VEnum ev       -> nameP $ unEnumValue ev
+
+dispatchStringPrinter t s = case t of
+  StringCharacter -> stringValue s
+  BlockStringCharacter -> blockStringValue s
 
 -- | We use Aeson to decode string values, and therefore use Aeson to encode them back.
 stringValue :: Printer a => Text -> a

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -246,7 +246,10 @@ value = \case
   VObject o   -> objectValue o
   VEnum ev    -> nameP $ unEnumValue ev
 
-dispatchStringPrinter s = undefined
+dispatchStringPrinter s = 
+  -- in here we are gonna decide how to print the string
+  -- according to heuristics
+  undefined
 
 -- | We use Aeson to decode string values, and therefore use Aeson to encode them back.
 stringValue :: Printer a => Text -> a

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -76,9 +76,6 @@ module Language.GraphQL.Draft.Syntax (
   , fmapSelectionSetFragment
   , fmapSelectionFragment
   , fmapInlineFragment
-
-  -- unsorted
-  , StringType(..)
   ) where
 
 import                qualified Data.Aeson                     as J
@@ -322,7 +319,7 @@ data Value var
   | VNull
   | VInt Integer
   | VFloat Scientific
-  | VString StringType Text
+  | VString Text
   | VBoolean Bool
   | VEnum EnumValue
   | VList [Value var]
@@ -335,7 +332,7 @@ instance Lift var => Lift (Value var) where
   liftTyped VNull         = [|| VNull ||]
   liftTyped (VInt a)      = [|| VInt a ||]
   liftTyped (VFloat a)    = [|| VFloat $ fromRational $$(TH.liftTyped $ toRational a) ||]
-  liftTyped (VString t a) = [|| VString t a ||]
+  liftTyped (VString a)   = [|| VString a ||]
   liftTyped (VBoolean a)  = [|| VBoolean a ||]
   liftTyped (VEnum a)     = [|| VEnum a ||]
   liftTyped (VList a)     = [|| VList a ||]
@@ -343,12 +340,6 @@ instance Lift var => Lift (Value var) where
 
 literal :: Value Void -> Value var
 literal = fmap absurd
-
-data StringType = StringCharacter | BlockStringCharacter
-  deriving (Show, Eq, Ord, Generic)
-instance Hashable StringType
-instance NFData StringType
-instance Lift StringType
 
 -- * Directives
 

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -76,6 +76,9 @@ module Language.GraphQL.Draft.Syntax (
   , fmapSelectionSetFragment
   , fmapSelectionFragment
   , fmapInlineFragment
+
+  -- unsorted
+  , StringType(..)
   ) where
 
 import                qualified Data.Aeson                     as J
@@ -319,8 +322,7 @@ data Value var
   | VNull
   | VInt Integer
   | VFloat Scientific
-  | VString Text
-  | VBlockString Text
+  | VString StringType Text
   | VBoolean Bool
   | VEnum EnumValue
   | VList [Value var]
@@ -329,19 +331,24 @@ data Value var
 instance Hashable var => Hashable (Value var)
 instance NFData   var => NFData   (Value var)
 instance Lift var => Lift (Value var) where
-  liftTyped (VVariable a)    = [|| VVariable a ||]
-  liftTyped VNull            = [|| VNull ||]
-  liftTyped (VInt a)         = [|| VInt a ||]
-  liftTyped (VFloat a)       = [|| VFloat $ fromRational $$(TH.liftTyped $ toRational a) ||]
-  liftTyped (VString a)      = [|| VString a ||]
-  liftTyped (VBlockString a) = [|| VBlockString a ||]
-  liftTyped (VBoolean a)     = [|| VBoolean a ||]
-  liftTyped (VEnum a)        = [|| VEnum a ||]
-  liftTyped (VList a)        = [|| VList a ||]
-  liftTyped (VObject a)      = [|| VObject $$(liftTypedHashMap a) ||]
+  liftTyped (VVariable a) = [|| VVariable a ||]
+  liftTyped VNull         = [|| VNull ||]
+  liftTyped (VInt a)      = [|| VInt a ||]
+  liftTyped (VFloat a)    = [|| VFloat $ fromRational $$(TH.liftTyped $ toRational a) ||]
+  liftTyped (VString t a) = [|| VString t a ||]
+  liftTyped (VBoolean a)  = [|| VBoolean a ||]
+  liftTyped (VEnum a)     = [|| VEnum a ||]
+  liftTyped (VList a)     = [|| VList a ||]
+  liftTyped (VObject a)   = [|| VObject $$(liftTypedHashMap a) ||]
 
 literal :: Value Void -> Value var
 literal = fmap absurd
+
+data StringType = StringCharacter | BlockStringCharacter
+  deriving (Show, Eq, Ord, Generic)
+instance Hashable StringType
+instance NFData StringType
+instance Lift StringType
 
 -- * Directives
 

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -92,7 +92,7 @@ import                          Data.Hashable
 import                          Data.Scientific
 import                          Data.String                    (IsString (..))
 import                          Data.Text                      (Text)
-import                          Data.Text.Prettyprint.Doc      (Pretty (..))
+import                          Prettyprinter                  (Pretty (..))
 import                          Data.Void
 import                          GHC.Generics                   (Generic)
 import                          Instances.TH.Lift              ()

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -320,6 +320,7 @@ data Value var
   | VInt Integer
   | VFloat Scientific
   | VString Text
+  | VBlockString Text
   | VBoolean Bool
   | VEnum EnumValue
   | VList [Value var]
@@ -328,15 +329,16 @@ data Value var
 instance Hashable var => Hashable (Value var)
 instance NFData   var => NFData   (Value var)
 instance Lift var => Lift (Value var) where
-  liftTyped (VVariable a) = [|| VVariable a ||]
-  liftTyped VNull         = [|| VNull ||]
-  liftTyped (VInt a)      = [|| VInt a ||]
-  liftTyped (VFloat a)    = [|| VFloat $ fromRational $$(TH.liftTyped $ toRational a) ||]
-  liftTyped (VString a)   = [|| VString a ||]
-  liftTyped (VBoolean a)  = [|| VBoolean a ||]
-  liftTyped (VEnum a)     = [|| VEnum a ||]
-  liftTyped (VList a)     = [|| VList a ||]
-  liftTyped (VObject a)   = [|| VObject $$(liftTypedHashMap a) ||]
+  liftTyped (VVariable a)    = [|| VVariable a ||]
+  liftTyped VNull            = [|| VNull ||]
+  liftTyped (VInt a)         = [|| VInt a ||]
+  liftTyped (VFloat a)       = [|| VFloat $ fromRational $$(TH.liftTyped $ toRational a) ||]
+  liftTyped (VString a)      = [|| VString a ||]
+  liftTyped (VBlockString a) = [|| VBlockString a ||]
+  liftTyped (VBoolean a)     = [|| VBoolean a ||]
+  liftTyped (VEnum a)        = [|| VEnum a ||]
+  liftTyped (VList a)        = [|| VList a ||]
+  liftTyped (VObject a)      = [|| VObject $$(liftTypedHashMap a) ||]
 
 literal :: Value Void -> Value var
 literal = fmap absurd

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -54,7 +54,7 @@ blockTest = do
 -- for errors using it.
 blockParseFail :: (T.Text -> T.Text) -> T.Text -> Property
 blockParseFail tripleQuoted unparsed = withTests 1 $ property $ do
-  case parseOnly blockString (tripleQuoted unparsed) of
+  case runParser blockString (tripleQuoted unparsed) of
     Left _ -> success
     Right _ -> do
       footnote ("Should have failed for: " <> T.unpack (tripleQuoted unparsed))

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -2,10 +2,10 @@
 
 module BlockStrings where
 
+import           Data.Attoparsec.Text
+import qualified Data.Text                     as T
 import           Hedgehog
 import           Language.GraphQL.Draft.Parser
-import qualified Data.Text as T
-import           Data.Attoparsec.Text
 
 blockTest :: IO Bool
 blockTest = do
@@ -29,11 +29,11 @@ blockTest = do
     , ("preserves escaped newlines", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
     , ("", blockParsesTo "\n\"\n" "\"")
     , ("escaped triple-quotes are ignored as block terminator", blockParsesTo "\n   \\\"\"\"hey\n   friends\n" "\\\"\"\"hey\nfriends")
-    , ("fails for normal string",blockParseFail (\t -> "\"" <> t <> "\"") "hey") 
-    , ("fails for block string that is not closed",blockParseFail (\t -> "\"\"\"" <> t) "hey") 
+    , ("fails for normal string",blockParseFail (\t -> "\"" <> t <> "\"") "hey")
+    , ("fails for block string that is not closed",blockParseFail ("\"\"\"" <>) "hey")
     , ("fails for block string that is not closed when there are escaped triple-quotes",
-          blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey") 
-    , ("does not ignore escaping when its part of a escaped tripel-quotes", 
+          blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey")
+    , ("does not ignore escaping when its part of a escaped tripel-quotes",
           blockParseFail (\t -> "\"\"\"" <> t <> "\"\"\"") "\\") -- this is a single \, but it touches the """ at the end
     ]
 
@@ -45,9 +45,9 @@ blockParseFail :: (T.Text -> T.Text) -> T.Text -> Property
 blockParseFail tripleQuoted unparsed =
   withTests 1 $ property $ do
     case parseOnly blockString (tripleQuoted unparsed) of
-      Left l -> () === ()
-      Right r -> do
-        footnote ("Should have failed for: "<>T.unpack (tripleQuoted unparsed))
+      Left _ -> () === ()
+      Right _ -> do
+        footnote ("Should have failed for: " <> T.unpack (tripleQuoted unparsed))
         failure
 
 -- | We use this to wrap the first argument with I've been
@@ -58,7 +58,7 @@ blockParsesTo unparsed expected =
   withTests 1 $ property $ do
     let result =
           case parseOnly blockString (tripleQuoted unparsed) of
-            Left l -> Left ("Block parser failed: " <> T.pack l)
+            Left l  -> Left ("Block parser failed: " <> T.pack l)
             Right r -> Right r
     either onError (expected ===) result
   where

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -25,12 +25,8 @@ blockTest = do
     , ("", blockParsesTo "\nx\n" "x")
     , ("empty single line", blockParsesTo "" "")
     , ("empty two lines", blockParsesTo "\n" "")
-    , ("empty three lines", blockParsesTo "\n\n" "") -- first is deleted, third is deleted
-    , ("empty four lines", blockParsesTo "\n\n\n" "\n")
-    , ("empty four lines", blockParsesTo "\n\n\n\n" "\n\n")
-    , ("empty four lines", blockParsesTo "\n\n\n\n\n" "\n\n\n")
-    , ("empty four lines", blockParsesTo "\n\n\n\n\n\n" "\n\n\n\n")
-    --, ("empty three lines", blockParsesTo "\n \n \n" "")
+    , ("empty three lines", blockParsesTo "\n\n" "")
+    , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
     ]
 
 -- note that this function is only for block strings

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -35,6 +35,10 @@ blockTest = do
           blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey") 
     ]
 
+-- | We use this function to tests cases that we know should
+-- fail, when we pass a function to construct wrapped the
+-- body in a delimiter, where we will probably be testing
+-- for errors using it.
 blockParseFail :: (T.Text -> T.Text) -> T.Text -> Property
 blockParseFail tripleQuoted unparsed =
   withTests 1 $ property $ do
@@ -44,8 +48,9 @@ blockParseFail tripleQuoted unparsed =
         footnote ("Should have failed for: "<>T.unpack (tripleQuoted unparsed))
         failure
 
--------------------------------------------------------------------
-
+-- | We use this to wrap the first argument with I've been
+-- calling "triple-quotes", which are the delimiters for the
+-- block strings.
 blockParsesTo :: T.Text -> T.Text -> Property
 blockParsesTo unparsed expected =
   withTests 1 $ property $ do

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -26,6 +26,10 @@ blockTest = do
     , ("empty two lines", blockParsesTo "\n" "")
     , ("empty three lines", blockParsesTo "\n\n" "")
     , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
+
+    , ("", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
+    , ("", blockParsesTo "\n\"\n" "\"")
+    , ("", blockParsesTo "\n\\\"\"\"\n" "\\\"\"\"")
     ]
 
 blockParsesTo :: T.Text -> T.Text -> Property
@@ -33,7 +37,7 @@ blockParsesTo unparsed expected =
   withTests 1 $ property $ do
     let result =
           case parseOnly blockString (tripleQuoted unparsed) of
-            Left l -> Left ("Parser failed: " <> T.pack l)
+            Left l -> Left ("Block parser failed: " <> T.pack l)
             Right r -> Right r
     either onError (expected ===) result
   where

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -29,8 +29,8 @@ blockTest = do
     , ("preserves escaped newlines", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
     , ("", blockParsesTo "\n\"\n" "\"")
     , ("escaped triple-quotes are ignored as block terminator", blockParsesTo "\n   \\\"\"\"hey\n   friends\n" "\\\"\"\"hey\nfriends")
-    , ("fails for normal string",blockParseFail (\t -> "\"" <> t <> "\"") "hey")
-    , ("fails for block string that is not closed",blockParseFail ("\"\"\"" <>) "hey")
+    , ("fails for normal string", blockParseFail (\t -> "\"" <> t <> "\"") "hey")
+    , ("fails for block string that is not closed", blockParseFail ("\"\"\"" <>) "hey")
     , ("fails for block string that is not closed when there are escaped triple-quotes",
           blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey")
     , ("does not ignore escaping when its part of a escaped tripel-quotes",

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -66,8 +66,8 @@ blockParseFail tripleQuoted unparsed = withTests 1 $ property $ do
 blockParsesTo :: T.Text -> T.Text -> Property
 blockParsesTo unparsed expected = withTests 1 $ property $ do
   let result =
-        case parseOnly blockString (tripleQuoted unparsed) of
-          Left l  -> Left ("Block parser failed: " <> T.pack l)
+        case runParser blockString (tripleQuoted unparsed) of
+          Left l  -> Left ("Block parser failed: " <> l)
           Right r -> Right r
   either onError (expected ===) result
   where

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -14,18 +14,21 @@ blockTest = do
     [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
     , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
     , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n\tqux")
+    , ("tabs work with spaces", blockParsesTo "\n\t Foo\n \tbar\n\t\t qux" "Foo\nbar\n qux")
     , ("parses empty string", blockParsesTo "" "")
     , ("parses newline", blockParsesTo "\n" "")
     , ("parses very simples not-empty block", blockParsesTo "x" "x")
+    , ("common indentation is removed", blockParsesTo "\n  a \n   b \n  c " "a \n b \nc ")
+    , ("zero common indentation is possible", blockParsesTo "\na \n b \nc " "a \n b \nc ")
+    , ("single lines works like a string", blockParsesTo "  abc " "  abc ")
+    , ("ignores escaping", blockParsesTo "  \\  " "  \\  ") -- this is a single \
+    , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
+    , ("", blockParsesTo "\nx\n" "x")
+    , ("", blockParsesTo "\n\n" "")
+    --, ("", blockParsesTo "\n\n\n\n" "\n\n") -- TODO this should not be failing
     --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
     --, ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
     {-
-    , ("parses block string containing a valid normal string inside", blockParsesTo "  \"i'm like a JSON string\"   " "\"i'm like a JSON string\"")
-    , ("parses not-empty block with newlines", blockParsesTo " \n   \n  \n x   \n y   \n\n " "x\ny")
-    , ("ignores escaping", blockParsesTo "  \\  " "\\") -- this is a single \
-    , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey")
-    , ("zero common indentation is possible", blockParsesTo " \naa \n  bbbb \ncccc " "aa\n  bbbb\ncccc")
-    , ("common indentation is removed", blockParsesTo " \n   i have 3 \n    i have 4 \n   i also have 3 " "i have 3\n i have 4\ni also have 3")
     -}
     ]
 

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -33,6 +33,8 @@ blockTest = do
     , ("fails for block string that is not closed",blockParseFail (\t -> "\"\"\"" <> t) "hey") 
     , ("fails for block string that is not closed when there are escaped triple-quotes",
           blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey") 
+          -- TODO
+    --, ("does not ignores escaping when its part of a escaped tripe-quotes", blockParsesTo "\\" "\\") -- this is a single \, but it touches the """ at the end
     ]
 
 -- | We use this function to tests cases that we know should

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -14,12 +14,12 @@ blockTest = do
     [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
     , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
     , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n\tqux")
-    --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
-    {-
     , ("parses empty string", blockParsesTo "" "")
     , ("parses newline", blockParsesTo "\n" "")
-    , ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
     , ("parses very simples not-empty block", blockParsesTo "x" "x")
+    --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
+    --, ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
+    {-
     , ("parses block string containing a valid normal string inside", blockParsesTo "  \"i'm like a JSON string\"   " "\"i'm like a JSON string\"")
     , ("parses not-empty block with newlines", blockParsesTo " \n   \n  \n x   \n y   \n\n " "x\ny")
     , ("ignores escaping", blockParsesTo "  \\  " "\\") -- this is a single \

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -20,13 +20,14 @@ blockTest = do
     , ("no whitespace is removed from the first line", blockParsesTo "  abc " "  abc ")
     , ("ignores escaping", blockParsesTo "  \\  " "  \\  ") -- this is a single \
     , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
-    , ("", blockParsesTo "\nx\n" "x")
+    , ("", blockParsesTo "\nx\n" "x") -- TODO missing description
     , ("empty single line", blockParsesTo "" "")
     , ("empty two lines", blockParsesTo "\n" "")
     , ("empty three lines", blockParsesTo "\n\n" "")
     , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
     , ("preserves escaped newlines", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
-    , ("", blockParsesTo "\n\"\n" "\"")
+    , ("", blockParsesTo "\n\"\n" "\"") -- TODO missing description
+    , ("", blockParsesTo "\n   \\\"\"\"\n   friends\n"     "\"\"\"hey\nfriends") -- TODO missing description
     , ("escaped triple-quotes are ignored as block terminator", blockParseFail "\n   \\\"\"\"hey\n   friends\n\"\"\"hey\nfriends")
     , ("fails for normal string", blockParseFail "\"hey\"")
     , ("fails for block string that is not closed", blockParseFail "\"\"\" hey")

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -29,7 +29,7 @@ blockTest = do
 
     , ("", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
     , ("", blockParsesTo "\n\"\n" "\"")
-    , ("", blockParsesTo "\n\\\"\"\"\n" "\\\"\"\"")
+    , ("escaped triple-quotes are ignored as block terminator", blockParsesTo "\n   \\\"\"\"hey\n   friends\n" "\\\"\"\"hey\nfriends")
     ]
 
 blockParsesTo :: T.Text -> T.Text -> Property

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -33,8 +33,8 @@ blockTest = do
     , ("fails for block string that is not closed",blockParseFail (\t -> "\"\"\"" <> t) "hey") 
     , ("fails for block string that is not closed when there are escaped triple-quotes",
           blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey") 
-          -- TODO
-    --, ("does not ignores escaping when its part of a escaped tripe-quotes", blockParsesTo "\\" "\\") -- this is a single \, but it touches the """ at the end
+    , ("does not ignore escaping when its part of a escaped tripel-quotes", 
+          blockParseFail (\t -> "\"\"\"" <> t <> "\"\"\"") "\\") -- this is a single \, but it touches the """ at the end
     ]
 
 -- | We use this function to tests cases that we know should

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -15,7 +15,6 @@ blockTest = do
     , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
     , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n\tqux")
     , ("tabs work with spaces", blockParsesTo "\n\t Foo\n \tbar\n\t\t qux" "Foo\nbar\n qux")
-    , ("parses empty string", blockParsesTo "" "")
     , ("parses newline", blockParsesTo "\n" "")
     , ("parses very simples not-empty block", blockParsesTo "x" "x")
     , ("common indentation is removed", blockParsesTo "\n  a \n   b \n  c " "a \n b \nc ")
@@ -24,13 +23,14 @@ blockTest = do
     , ("ignores escaping", blockParsesTo "  \\  " "  \\  ") -- this is a single \
     , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
     , ("", blockParsesTo "\nx\n" "x")
-    , ("", blockParsesTo "\n\n" "")
-    --, ("", blockParsesTo "\n\n\n\n" "\n\n")
-    --, ("", blockParsesTo "\n \n \n\n " " \n \n")
-    --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
-    --, ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
-    {-
-    -}
+    , ("empty single line", blockParsesTo "" "")
+    , ("empty two lines", blockParsesTo "\n" "")
+    , ("empty three lines", blockParsesTo "\n\n" "") -- first is deleted, third is deleted
+    , ("empty four lines", blockParsesTo "\n\n\n" "\n")
+    , ("empty four lines", blockParsesTo "\n\n\n\n" "\n\n")
+    , ("empty four lines", blockParsesTo "\n\n\n\n\n" "\n\n\n")
+    , ("empty four lines", blockParsesTo "\n\n\n\n\n\n" "\n\n\n\n")
+    --, ("empty three lines", blockParsesTo "\n \n \n" "")
     ]
 
 -- note that this function is only for block strings

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -27,25 +27,23 @@ blockTest = do
     , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
     , ("preserves escaped newlines", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
     , ("", blockParsesTo "\n\"\n" "\"")
-    , ("escaped triple-quotes are ignored as block terminator", blockParsesTo "\n   \\\"\"\"hey\n   friends\n" "\"\"\"hey\nfriends")
-    , ("fails for normal string", blockParseFail (\t -> "\"" <> t <> "\"") "hey")
-    , ("fails for block string that is not closed", blockParseFail ("\"\"\"" <>) "hey")
-    , ("fails for block string that is not closed when there are escaped triple-quotes",
-          blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey")
-    , ("does not ignore escaping when it's part of an escaped triple-quotes",
-          blockParseFail (\t -> "\"\"\"" <> t <> "\"\"\"") "\\") -- this is a single \, but it touches the """ at the end
+    , ("escaped triple-quotes are ignored as block terminator", blockParseFail "\n   \\\"\"\"hey\n   friends\n\"\"\"hey\nfriends")
+    , ("fails for normal string", blockParseFail "\"hey\"")
+    , ("fails for block string that is not closed", blockParseFail "\"\"\" hey")
+    , ("fails for block string that is not closed when there are escaped triple-quotes", blockParseFail "\"\"\" hey\\\"\"\"hey")
+    , ("does not ignore escaping when it's part of an escaped triple-quotes", blockParseFail "\"\"\"\\\"\"\"" ) -- this is a single \, but it touches the """ at the end
     ]
 
 -- | We use this function to tests cases that we know should
 -- fail, when we pass a function to construct wrapped the
 -- body in a delimiter, where we will probably be testing
 -- for errors using it.
-blockParseFail :: (T.Text -> T.Text) -> T.Text -> Property
-blockParseFail tripleQuoted unparsed = withTests 1 $ property $ do
-  case runParser blockString (tripleQuoted unparsed) of
+blockParseFail :: T.Text -> Property
+blockParseFail unparsed = withTests 1 $ property $ do
+  case runParser blockString ("\"\"\"" <> unparsed <> "\"\"\"") of
     Left _ -> success
     Right _ -> do
-      footnote ("Should have failed for: " <> T.unpack (tripleQuoted unparsed))
+      footnote ("Should have failed for: " <> T.unpack ("\"\"\"" <> unparsed <> "\"\"\""))
       failure
 
 -- | Test whether certain block string content parses to the expected value.

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -1,0 +1,42 @@
+
+-- | Regression tests for issue #20 https://github.com/hasura/graphql-parser-hs/issues/20
+
+module BlockStrings where
+
+import           Hedgehog
+import           Language.GraphQL.Draft.Parser
+import qualified Data.Text as T
+import           Data.Attoparsec.Text
+
+blockTest :: IO Bool
+blockTest = do
+  checkParallel $ Group "Test.parser.block-string.unit"
+    [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
+    , ("parses empty string", blockParsesTo "" "")
+    , ("parses newline", blockParsesTo "\n" "")
+    , ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
+    , ("parses very simples not-empty block", blockParsesTo "x" "x")
+    , ("parses block string containing a valid normal string inside", blockParsesTo "  \"i'm like a JSON string\"   " "\"i'm like a JSON string\"")
+    , ("parses not-empty block with newlines", blockParsesTo " \n   \n  \n x   \n y   \n\n " "x\ny")
+    , ("ignores escaping", blockParsesTo "  \\  " "\\") -- this is a single \
+    , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey")
+    , ("zero common indentation is possible", blockParsesTo " \naa \n  bbbb \ncccc " "aa\n  bbbb\ncccc")
+    , ("common indentation is removed", blockParsesTo " \n   i have 3 \n    i have 4 \n   i also have 3 " "i have 3\n i have 4\ni also have 3")
+    ]
+
+-- note that this function is only for block strings
+blockParsesTo :: T.Text -> T.Text -> Property
+blockParsesTo unparsed expected =
+  withTests 1 $ property $ do
+    let result =
+          case parseOnly blockString (tripleQuoted unparsed) of
+            Left l -> Left ("Parser failed: " <> T.pack l)
+            Right r -> Right r
+    either onError (expected ===) result
+  where
+    onError errorMsg = do
+      footnote (T.unpack errorMsg)
+      failure
+
+tripleQuoted :: T.Text -> T.Text
+tripleQuoted t = "\"\"\"" <> t <> "\"\"\""

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -9,26 +9,25 @@ import           Language.GraphQL.Draft.Parser
 blockTest :: IO Bool
 blockTest = do
   checkParallel $ Group "Test.parser.block-string.unit"
-    [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
-    , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
-    , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n\tqux")
-    , ("tabs work with spaces", blockParsesTo "\n\t Foo\n \tbar\n\t\t qux" "Foo\nbar\n qux")
-    , ("parses newline", blockParsesTo "\n" "")
-    , ("parses very simples not-empty block", blockParsesTo "x" "x")
-    , ("common indentation is removed", blockParsesTo "\n  a \n   b \n  c " "a \n b \nc ")
-    , ("zero common indentation is possible", blockParsesTo "\na \n b \nc " "a \n b \nc ")
-    , ("no whitespace is removed from the first line", blockParsesTo "  abc " "  abc ")
-    , ("ignores escaping", blockParsesTo "  \\  " "  \\  ") -- this is a single \
-    , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
-    , ("", blockParsesTo "\nx\n" "x") -- TODO missing description
-    , ("empty single line", blockParsesTo "" "")
-    , ("empty two lines", blockParsesTo "\n" "")
-    , ("empty three lines", blockParsesTo "\n\n" "")
-    , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
-    , ("preserves escaped newlines", blockParsesTo "\nhello\\nworld\n" "hello\\nworld")
-    , ("", blockParsesTo "\n\"\n" "\"") -- TODO missing description
-    , ("", blockParsesTo "\n   \\\"\"\"\n   friends\n"     "\"\"\"hey\nfriends") -- TODO missing description
-    , ("escaped triple-quotes are ignored as block terminator", blockParseFail "\n   \\\"\"\"hey\n   friends\n\"\"\"hey\nfriends")
+    [ ("parses the specExample", "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " `shouldParseTo` "Hello,\n  World!\n\nYours,\n  GraphQL.")
+    , ("do not remove WS from the end of lines", "\nFoo \nbar  " `shouldParseTo` "Foo \nbar  ")
+    , ("tabs are WS as well", "\n\t\tFoo\n\t\tbar\n\t\t\tqux" `shouldParseTo` "Foo\nbar\n\tqux")
+    , ("tabs work with spaces", "\n\t Foo\n \tbar\n\t\t qux" `shouldParseTo` "Foo\nbar\n qux")
+    , ("parses newline", "\n" `shouldParseTo` "")
+    , ("parses very simples not-empty block", "x" `shouldParseTo` "x")
+    , ("common indentation is removed", "\n  a \n   b \n  c " `shouldParseTo` "a \n b \nc ")
+    , ("zero common indentation is possible", "\na \n b \nc " `shouldParseTo` "a \n b \nc ")
+    , ("no whitespace is removed from the first line", "  abc " `shouldParseTo` "  abc ")
+    , ("ignores escaping", "  \\  " `shouldParseTo` "  \\  ") -- this is a single \
+    , ("\n in first characters is parsed", "\n hey  " `shouldParseTo` "hey  ")
+    , ("simple case", "\nx\n" `shouldParseTo` "x")
+    , ("empty single line", "" `shouldParseTo` "")
+    , ("empty two lines", "\n" `shouldParseTo` "")
+    , ("empty three lines", "\n\n" `shouldParseTo` "")
+    , ("empty X lines", "\n\n\n\n\n\n" `shouldParseTo` "")
+    , ("preserves escaped newlines", "\nhello\\nworld\n" `shouldParseTo` "hello\\nworld")
+    , ("double-quotes are parsed normally", "\n\"\n" `shouldParseTo` "\"")
+    , ("escaped triple-quotes are ignored as block terminator", "\n   \\\"\"\"hey\n   friends\n" `shouldParseTo` "\"\"\"hey\nfriends")
     , ("fails for normal string", blockParseFail "\"hey\"")
     , ("fails for block string that is not closed", blockParseFail "\"\"\" hey")
     , ("fails for block string that is not closed when there are escaped triple-quotes", blockParseFail "\"\"\" hey\\\"\"\"hey")
@@ -48,8 +47,8 @@ blockParseFail unparsed = withTests 1 $ property $ do
       failure
 
 -- | Test whether certain block string content parses to the expected value.
-blockParsesTo :: T.Text -> T.Text -> Property
-blockParsesTo unparsed expected = withTests 1 $ property $ do
+shouldParseTo :: T.Text -> T.Text -> Property
+shouldParseTo unparsed expected = withTests 1 $ property $ do
   case runParser blockString ("\"\"\"" <> unparsed <> "\"\"\"") of
     Right r -> expected === r
     Left l  -> do

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -12,6 +12,11 @@ blockTest :: IO Bool
 blockTest = do
   checkParallel $ Group "Test.parser.block-string.unit"
     [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
+    , ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
+    , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
+    , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n qux")
+
+    {-
     , ("parses empty string", blockParsesTo "" "")
     , ("parses newline", blockParsesTo "\n" "")
     , ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
@@ -22,6 +27,7 @@ blockTest = do
     , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey")
     , ("zero common indentation is possible", blockParsesTo " \naa \n  bbbb \ncccc " "aa\n  bbbb\ncccc")
     , ("common indentation is removed", blockParsesTo " \n   i have 3 \n    i have 4 \n   i also have 3 " "i have 3\n i have 4\ni also have 3")
+    -}
     ]
 
 -- note that this function is only for block strings

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -3,9 +3,14 @@
 module BlockStrings where
 
 import           Data.Attoparsec.Text
-import qualified Data.Text                     as T
+import qualified Data.Text                      as T
+import qualified Data.Text.Prettyprint.Doc      as PP
+import           Data.Void                      (Void)
 import           Hedgehog
 import           Language.GraphQL.Draft.Parser
+import qualified Language.GraphQL.Draft.Printer as Printer
+import           Language.GraphQL.Draft.Syntax
+import qualified Prettyprinter.Render.Text      as PP
 
 blockTest :: IO Bool
 blockTest = do
@@ -35,6 +40,12 @@ blockTest = do
           blockParseFail (\t -> "\"\"\"" <> t <> "\\\"\"\"" <> t) "hey")
     , ("does not ignore escaping when its part of a escaped tripel-quotes",
           blockParseFail (\t -> "\"\"\"" <> t <> "\"\"\"") "\\") -- this is a single \, but it touches the """ at the end
+
+    -- Printing
+    , ("a line with indentation prints as blockstring", printsAsBlockString (VString "foo\n    indented!"))
+    , ("when starts with indentation prints a regular string", printsAsString (VString "    indented!"))
+    , ("when has escaped newlines prints as regular string", printsAsString (VString "foo\\n    indented!"))
+    , ("when it has non-printable chars it prints as regular string", printsAsString (VString "\NUL\n    indented!"))
     ]
 
 -- | We use this function to tests cases that we know should
@@ -42,27 +53,44 @@ blockTest = do
 -- body in a delimiter, where we will probably be testing
 -- for errors using it.
 blockParseFail :: (T.Text -> T.Text) -> T.Text -> Property
-blockParseFail tripleQuoted unparsed =
-  withTests 1 $ property $ do
-    case parseOnly blockString (tripleQuoted unparsed) of
-      Left _ -> () === ()
-      Right _ -> do
-        footnote ("Should have failed for: " <> T.unpack (tripleQuoted unparsed))
-        failure
+blockParseFail tripleQuoted unparsed = withTests 1 $ property $ do
+  case parseOnly blockString (tripleQuoted unparsed) of
+    Left _ -> success
+    Right _ -> do
+      footnote ("Should have failed for: " <> T.unpack (tripleQuoted unparsed))
+      failure
 
 -- | We use this to wrap the first argument with I've been
 -- calling "triple-quotes", which are the delimiters for the
 -- block strings.
 blockParsesTo :: T.Text -> T.Text -> Property
-blockParsesTo unparsed expected =
-  withTests 1 $ property $ do
-    let result =
-          case parseOnly blockString (tripleQuoted unparsed) of
-            Left l  -> Left ("Block parser failed: " <> T.pack l)
-            Right r -> Right r
-    either onError (expected ===) result
+blockParsesTo unparsed expected = withTests 1 $ property $ do
+  let result =
+        case parseOnly blockString (tripleQuoted unparsed) of
+          Left l  -> Left ("Block parser failed: " <> T.pack l)
+          Right r -> Right r
+  either onError (expected ===) result
   where
     onError errorMsg = do
       footnote (T.unpack errorMsg)
       failure
     tripleQuoted t = "\"\"\"" <> t <> "\"\"\""
+
+printsAsBlockString :: Value Void -> Property
+printsAsBlockString val = withTests 1 $ property $ do
+  let printed = prettyPrinter . Printer.value $ val
+  footnote $ "should have been printed as a BlockString: " <> T.unpack printed
+  assert ("\"\"\"" `T.isPrefixOf` printed)
+  assert ("\"\"\"" `T.isSuffixOf` printed)
+  where
+    prettyPrinter :: PP.Doc T.Text -> T.Text
+    prettyPrinter = PP.renderStrict . PP.layoutPretty PP.defaultLayoutOptions
+
+printsAsString :: Value Void -> Property
+printsAsString val = withTests 1 $ property do
+  let printed = prettyPrinter . Printer.value $ val
+  footnote ("should have been printed as a String: " <> T.unpack printed)
+  assert (not $ "\"\"\"" `T.isPrefixOf` printed)
+  where
+    prettyPrinter :: PP.Doc T.Text -> T.Text
+    prettyPrinter = PP.renderStrict . PP.layoutPretty PP.defaultLayoutOptions

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -12,10 +12,9 @@ blockTest :: IO Bool
 blockTest = do
   checkParallel $ Group "Test.parser.block-string.unit"
     [ ("parses the specExample", blockParsesTo "\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  " "Hello,\n  World!\n\nYours,\n  GraphQL.")
-    , ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
     , ("do not remove WS from the end of lines", blockParsesTo "\nFoo \nbar  " "Foo \nbar  ")
-    , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n qux")
-
+    , ("tabs are WS as well", blockParsesTo "\n\t\tFoo\n\t\tbar\n\t\t\tqux" "Foo\nbar\n\tqux")
+    --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
     {-
     , ("parses empty string", blockParsesTo "" "")
     , ("parses newline", blockParsesTo "\n" "")

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -1,4 +1,3 @@
-
 -- | Regression tests for issue #20 https://github.com/hasura/graphql-parser-hs/issues/20
 
 module BlockStrings where
@@ -29,7 +28,6 @@ blockTest = do
     , ("empty X lines", blockParsesTo "\n\n\n\n\n\n" "")
     ]
 
--- note that this function is only for block strings
 blockParsesTo :: T.Text -> T.Text -> Property
 blockParsesTo unparsed expected =
   withTests 1 $ property $ do
@@ -42,6 +40,5 @@ blockParsesTo unparsed expected =
     onError errorMsg = do
       footnote (T.unpack errorMsg)
       failure
-
-tripleQuoted :: T.Text -> T.Text
-tripleQuoted t = "\"\"\"" <> t <> "\"\"\""
+    tripleQuoted :: T.Text -> T.Text
+    tripleQuoted t = "\"\"\"" <> t <> "\"\"\""

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -25,7 +25,8 @@ blockTest = do
     , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
     , ("", blockParsesTo "\nx\n" "x")
     , ("", blockParsesTo "\n\n" "")
-    --, ("", blockParsesTo "\n\n\n\n" "\n\n") -- TODO this should not be failing
+    --, ("", blockParsesTo "\n\n\n\n" "\n\n")
+    --, ("", blockParsesTo "\n \n \n\n " " \n \n")
     --, ("only strip first and last empty lines", blockParsesTo "\n \n \n \n\n " " \n \n \n")
     --, ("parses newlines in empty block", blockParsesTo " \n   \n  \n            \n\n " "")
     {-

--- a/test/BlockStrings.hs
+++ b/test/BlockStrings.hs
@@ -18,7 +18,7 @@ blockTest = do
     , ("parses very simples not-empty block", blockParsesTo "x" "x")
     , ("common indentation is removed", blockParsesTo "\n  a \n   b \n  c " "a \n b \nc ")
     , ("zero common indentation is possible", blockParsesTo "\na \n b \nc " "a \n b \nc ")
-    , ("single lines works like a string", blockParsesTo "  abc " "  abc ")
+    , ("no whitespace is removed from the first line", blockParsesTo "  abc " "  abc ")
     , ("ignores escaping", blockParsesTo "  \\  " "  \\  ") -- this is a single \
     , ("\n in first characters is parsed", blockParsesTo "\n hey  " "hey  ")
     , ("", blockParsesTo "\nx\n" "x")

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -55,7 +55,6 @@ propHandleUnicodeCharacters = property $ for_ [minBound..maxBound] \c ->
 propHandleTripleQuote :: Property
 propHandleTripleQuote = property $ testRoundTripValue $ VString "\"\"\""
 
-
 testRoundTripValue :: Value Void -> PropertyT IO ()
 testRoundTripValue = testRoundTrip value P.value
 

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -39,17 +39,17 @@ propNullNameName :: Property
 propNullNameName = property $ testRoundTrip nameParser P.nameP $$(litName "nullColumntwo")
 
 propHandleNulString :: Property
-propHandleNulString = property $ testRoundTripValue $ VString StringCharacter "\NUL"
+propHandleNulString = property $ testRoundTripValue $ VString "\NUL"
 
 propHandleNewlineString :: Property
-propHandleNewlineString = property $ testRoundTripValue $ VString StringCharacter "\n"
+propHandleNewlineString = property $ testRoundTripValue $ VString "\n"
 
 propHandleControlString :: Property
-propHandleControlString = property $ testRoundTripValue $ VString StringCharacter "\x0011"
+propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
 
 propHandleUnicodeCharacters :: Property
 propHandleUnicodeCharacters = property $ for_ [minBound..maxBound] \c ->
-  testRoundTripValue $ VString StringCharacter $ singleton c
+  testRoundTripValue $ VString $ singleton c
 
 
 testRoundTripValue :: Value Void -> PropertyT IO ()

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -26,6 +26,7 @@ primitiveTests =
   , ("a string containing \\n is handled correctly", withTests 1 propHandleNewlineString)
   , ("a string containing \\x0011 is handled correctly", withTests 1 propHandleControlString)
   , ("all unicode characters are supported", withTests 1 propHandleUnicodeCharacters)
+  , ("triple quotes is a valid string", withTests 1 propHandleTripleQuote)
   ]
 
 
@@ -50,6 +51,9 @@ propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
 propHandleUnicodeCharacters :: Property
 propHandleUnicodeCharacters = property $ for_ [minBound..maxBound] \c ->
   testRoundTripValue $ VString $ singleton c
+
+propHandleTripleQuote :: Property
+propHandleTripleQuote = property $ testRoundTripValue $ VString "\"\"\""
 
 
 testRoundTripValue :: Value Void -> PropertyT IO ()

--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -39,17 +39,17 @@ propNullNameName :: Property
 propNullNameName = property $ testRoundTrip nameParser P.nameP $$(litName "nullColumntwo")
 
 propHandleNulString :: Property
-propHandleNulString = property $ testRoundTripValue $ VString "\NUL"
+propHandleNulString = property $ testRoundTripValue $ VString StringCharacter "\NUL"
 
 propHandleNewlineString :: Property
-propHandleNewlineString = property $ testRoundTripValue $ VString "\n"
+propHandleNewlineString = property $ testRoundTripValue $ VString StringCharacter "\n"
 
 propHandleControlString :: Property
-propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
+propHandleControlString = property $ testRoundTripValue $ VString StringCharacter "\x0011"
 
 propHandleUnicodeCharacters :: Property
 propHandleUnicodeCharacters = property $ for_ [minBound..maxBound] \c ->
-  testRoundTripValue $ VString $ singleton c
+  testRoundTripValue $ VString StringCharacter $ singleton c
 
 
 testRoundTripValue :: Value Void -> PropertyT IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,8 +22,8 @@ import qualified Language.GraphQL.Draft.Parser         as Input
 import qualified Language.GraphQL.Draft.Printer        as Output
 import           Language.GraphQL.Draft.Syntax
 
-import           Keywords
 import           BlockStrings
+import           Keywords
 
 data TestMode = TMDev | TMQuick | TMRelease
   deriving (Show)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,7 +24,6 @@ import           Language.GraphQL.Draft.Syntax
 
 import           Keywords
 import           BlockStrings
-import Debug.Trace
 
 data TestMode = TMDev | TMQuick | TMRelease
   deriving (Show)
@@ -78,8 +77,8 @@ mkPropParserPrinter :: (ExecutableDocument Name -> T.Text) -> (TestLimit -> Prop
 mkPropParserPrinter printer = \space ->
   withTests space $ property $ do
     someRandomDoc <- forAll genExecutableDocument
-    let rendered = traceShowId $ printer <$> Input.parseExecutableDoc (printer someRandomDoc)
-    let reRendered = traceShowId $ printer <$> (Input.parseExecutableDoc =<< rendered)
+    let rendered = printer <$> Input.parseExecutableDoc (printer someRandomDoc)
+    let reRendered = printer <$> (Input.parseExecutableDoc =<< rendered)
     case (rendered, reRendered) of
         (Left  e, _      ) -> onError e
         (_      , Left  e) -> onError e

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,9 +44,10 @@ main = do
 
 runTest :: TestLimit -> IO ()
 runTest limit = do
-  allGood1 <- tests limit
+  --allGood1 <- tests limit
   allGood2 <- blockTest
-  unless (allGood1 && allGood2) exitFailure
+  unless allGood2 exitFailure
+  --unless (allGood1 && allGood2) exitFailure
 
 tests :: TestLimit -> IO Bool
 tests nTests =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,7 +13,7 @@ import qualified Data.Text.Encoding.Error              as TE
 import qualified Data.Text.Lazy                        as TL
 import qualified Data.Text.Lazy.Builder                as TL
 import qualified Data.Text.Lazy.Encoding               as TL
-import qualified Data.Text.Prettyprint.Doc             as PP
+import qualified Prettyprinter                         as PP
 import qualified Data.Text.Prettyprint.Doc.Render.Text as PP
 import qualified Text.Builder                          as TB
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,6 +23,7 @@ import qualified Language.GraphQL.Draft.Printer        as Output
 import           Language.GraphQL.Draft.Syntax
 
 import           Keywords
+import           BlockStrings
 
 data TestMode = TMDev | TMQuick | TMRelease
   deriving (Show)
@@ -43,8 +44,10 @@ main = do
 
 runTest :: TestLimit -> IO ()
 runTest limit = do
-  allGood <- tests limit
-  unless allGood exitFailure
+
+  allGood1 <- tests limit
+  allGood2 <- blockTest
+  unless (allGood1 && allGood2) exitFailure
 
 tests :: TestLimit -> IO Bool
 tests nTests =
@@ -74,13 +77,20 @@ propParserBSPrinter = mkPropParserPrinter $ bsToTxt . BS.toLazyByteString . Outp
 mkPropParserPrinter :: (ExecutableDocument Name -> T.Text) -> (TestLimit -> Property)
 mkPropParserPrinter printer = \space ->
   withTests space $ property $ do
-    xs <- forAll genExecutableDocument
-    let rendered = printer xs
-    either onError (xs ===) $ Input.parseExecutableDoc rendered
+    someRandomDoc <- forAll genExecutableDocument
+    let rendered = printer <$> Input.parseExecutableDoc (printer someRandomDoc)
+    -- the reason why we render twice is to make sure that
+    -- when comparing we already "normalized" the block
+    -- string, so each reparsing of the blockstring will no
+    -- longer be different because the indentations are
+    -- already at the minimun possible.
+    let reRendered = printer <$> (Input.parseExecutableDoc =<< rendered)
+    case (rendered, reRendered) of
+        (Left  e, _      ) -> onError e
+        (_      , Left  e) -> onError e
+        (Right a, Right b) -> a === b
   where
-    onError (T.unpack -> errorMsg) = do
-      footnote errorMsg
-      failure
+    onError (T.unpack -> errorMsg) = footnote errorMsg >> failure
 
 bsToTxt :: BL.ByteString -> T.Text
 bsToTxt = TL.toStrict . TL.decodeUtf8With TE.lenientDecode

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,6 +24,7 @@ import           Language.GraphQL.Draft.Syntax
 
 import           Keywords
 import           BlockStrings
+import Debug.Trace
 
 data TestMode = TMDev | TMQuick | TMRelease
   deriving (Show)
@@ -77,8 +78,8 @@ mkPropParserPrinter :: (ExecutableDocument Name -> T.Text) -> (TestLimit -> Prop
 mkPropParserPrinter printer = \space ->
   withTests space $ property $ do
     someRandomDoc <- forAll genExecutableDocument
-    let rendered = printer <$> Input.parseExecutableDoc (printer someRandomDoc)
-    let reRendered = printer <$> (Input.parseExecutableDoc =<< rendered)
+    let rendered = traceShowId $ printer <$> Input.parseExecutableDoc (printer someRandomDoc)
+    let reRendered = traceShowId $ printer <$> (Input.parseExecutableDoc =<< rendered)
     case (rendered, reRendered) of
         (Left  e, _      ) -> onError e
         (_      , Left  e) -> onError e

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,7 +44,6 @@ main = do
 
 runTest :: TestLimit -> IO ()
 runTest limit = do
-
   allGood1 <- tests limit
   allGood2 <- blockTest
   unless (allGood1 && allGood2) exitFailure

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -78,11 +78,6 @@ mkPropParserPrinter printer = \space ->
   withTests space $ property $ do
     someRandomDoc <- forAll genExecutableDocument
     let rendered = printer <$> Input.parseExecutableDoc (printer someRandomDoc)
-    -- the reason why we render twice is to make sure that
-    -- when comparing we already "normalized" the block
-    -- string, so each reparsing of the blockstring will no
-    -- longer be different because the indentations are
-    -- already at the minimun possible.
     let reRendered = printer <$> (Input.parseExecutableDoc =<< rendered)
     case (rendered, reRendered) of
         (Left  e, _      ) -> onError e

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,10 +44,9 @@ main = do
 
 runTest :: TestLimit -> IO ()
 runTest limit = do
-  --allGood1 <- tests limit
+  allGood1 <- tests limit
   allGood2 <- blockTest
-  unless allGood2 exitFailure
-  --unless (allGood1 && allGood2) exitFailure
+  unless (allGood1 && allGood2) exitFailure
 
 tests :: TestLimit -> IO Bool
 tests nTests =


### PR DESCRIPTION
### Motivation

Current implementation is missing **Block Strings,** as mentioned
in the spec. In here we describe what changed, how and why.

Related to #30.

### Reasoning

Since we needed an implementation that preserved block strings
in the AST so we could reprint it as a block string and not
just as normal string, we opted for adding a new constructor
to the AST. For this constructor we added a new parser, printer
and generator, besides the needed tests.

In the old tests we changed the property tests for the cycle
_"parse→print→parse"_ so they can have a notion of idempotency
that also accommodates the block strings; the thing with block strings
is that after parsed once the excess indentation is removed
and when printed the resulting string is different (although
equivalent) to the original one, so the property _"parse (print
ast) = ast"_ is not true in the first parsing, but it will be
true to all the subsequent ones (where the common indentation
stays at zero forever).

### Implementation

In the generator file now we have the main generator for
block strings _"genBlockText"_ and a couple helper functions. In
the parser file we changed the value parser to include block
strings, and we also created the _"blockString"_ parser. The
printer is pretty much standard and in the syntax file we just
added the constructor and updated the needed instances.

We added the unit tests for block strings and the idempotency test.
The idempotency is tested both in the old property tests that now
check the idempotency in one or two parsings, but we also test
it in the file where the future property tests for block strings
will be.

### Consequences

Probably not many; the changes should impact normal strings,
descriptions and block strings. Nothing else should be affected.

### Further work to be done

We decided to first get the input of you guys in what has been
done so far so we can proceed with the missing stuff, which are:

- Optimizations. We have a naive implementation.
- Some property tests are just placeholders at the moment.
- Unit tests might be turned into property tests. (at least a couple)