### PR TITLE
add some additional test cases

### DIFF
--- a/src/Language/GraphQL/Draft/Generator.hs
+++ b/src/Language/GraphQL/Draft/Generator.hs
@@ -34,26 +34,28 @@ generate = Gen.sample
 
 genDocument :: Gen Document
 genDocument =
-  Document <$> Gen.list (Range.linear 1 3) genDefinition
+  Document <$> Gen.list (Range.linear 0 3) genDefinition
 
 genExecutableDocument :: Generator a => Gen (ExecutableDocument a)
 genExecutableDocument =
   ExecutableDocument <$> Gen.list (Range.linear 1 3) genExecutableDefinition
-
-genSchemaDocument :: Gen SchemaDocument
-genSchemaDocument =
-  SchemaDocument <$> Gen.list (Range.linear 1 5) genTypeSystemDefinition
 
 
 
 -- | *Identifiers*
 
 genText :: Gen Text
-genText = Gen.text (Range.linear 1 11) Gen.unicode
+genText = Gen.text (Range.linear 0 11) Gen.unicode
+
+alpha_ :: Gen Char
+alpha_ = Gen.choice [Gen.alpha, pure '_']
+
+alphaNum_ :: Gen Char
+alphaNum_ = Gen.choice [Gen.alphaNum, pure '_']
 
 genGraphqlName :: Gen Text
-genGraphqlName = Gen.text (Range.singleton 1) Gen.alpha <>
-                 Gen.text (Range.linear 1 11) Gen.alphaNum
+genGraphqlName = Gen.text (Range.singleton 1) alpha_ <>
+                 Gen.text (Range.linear 0 11) alphaNum_
 
 genName :: Gen Name
 genName = unsafeMkName <$> genGraphqlName
@@ -293,7 +295,7 @@ genTypeSystemDirectiveLocation =
 -- | *Structure*
 
 genSelectionSet :: Generator a => Gen (SelectionSet FragmentSpread a)
-genSelectionSet = mkList genSelection
+genSelectionSet = mkListNonEmpty genSelection
 
 genSelection :: Generator a => Gen (Selection FragmentSpread a)
 genSelection =
@@ -339,4 +341,7 @@ genArgument = (,) <$> genName <*> genValue
 -- | *Helpers*
 
 mkList :: Gen a -> Gen [a]
-mkList = Gen.list $ Range.linear 1 11
+mkList = Gen.list $ Range.linear 0 11
+
+mkListNonEmpty :: Gen a -> Gen [a]
+mkListNonEmpty = Gen.list $ Range.linear 1 11


### PR DESCRIPTION
This adds various empty lists, empty strings, and shorter GraphQL names to the generators.

For instance, before this PR, the shortest GraphQL being generated was `aa`. After this PR, it is `a`. Also, it adds underscore as a possible character in GraphQL names.