### PR TITLE
Updates roundtrip tests

### DIFF
--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -1,19 +1,27 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- | Regression tests for issue #20 https://github.com/hasura/graphql-parser-hs/issues/20
 module Keywords (primitiveTests) where
 
 import Data.Foldable (for_)
-import Data.String
-import Data.Text (singleton, unpack)
-import Data.Void
+import Data.Text (Text, singleton)
+import Data.Void (Void)
 import Hedgehog
-import Language.GraphQL.Draft.Parser
-import qualified Language.GraphQL.Draft.Printer as P
-import Language.GraphQL.Draft.Syntax
+  ( MonadTest,
+    Property,
+    PropertyName,
+    liftTest,
+    property,
+    tripping,
+    withTests,
+  )
+import Language.GraphQL.Draft.Parser (Parser, nameParser, runParser, value)
+import qualified Language.GraphQL.Draft.Printer as Printer
+import Language.GraphQL.Draft.Syntax (EnumValue (..), Value (..), litName)
 import Text.Builder (Builder, run)
 
-primitiveTests :: IsString s => [(s, Property)]
+primitiveTests :: [(PropertyName, Property)]
 primitiveTests =
   [ ("a \"null\" prefix doesn't prevent parsing a name", withTests 1 propNullNameName),
     ("a \"null\" prefix doesn't prevent parsing an enum name", withTests 1 propNullNameValue),
@@ -26,22 +34,28 @@ primitiveTests =
   ]
 
 propNullNameValue :: Property
-propNullNameValue = property $ testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "nullColumn")]
+propNullNameValue =
+  property . roundtripValue $
+    VList [VEnum $ EnumValue $$(litName "nullColumn")]
 
 propBoolNameValue :: Property
-propBoolNameValue = property $ testRoundTripValue $ VList [VEnum $ EnumValue $$(litName "trueColumn")]
+propBoolNameValue =
+  property . roundtripValue $
+    VList [VEnum $ EnumValue $$(litName "trueColumn")]
 
 propNullNameName :: Property
-propNullNameName = property $ testRoundTrip nameParser P.nameP $$(litName "nullColumntwo")
+propNullNameName =
+  property $
+    roundtripParser nameParser Printer.nameP $$(litName "nullColumntwo")
 
 propHandleNulString :: Property
-propHandleNulString = property $ testRoundTripValue $ VString "\NUL"
+propHandleNulString = property . roundtripValue $ VString "\NUL"
 
 propHandleNewlineString :: Property
-propHandleNewlineString = property $ testRoundTripValue $ VString "\n"
+propHandleNewlineString = property . roundtripValue $ VString "\n"
 
 propHandleControlString :: Property
-propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
+propHandleControlString = property . roundtripValue $ VString "\x0011"
 
 -- NB: 'liftTest' is explicitly used to restrict the 'for_' block to operate in
 -- the 'Test' type (i.e. 'type Test = TestT Identity'), as opposed to 'PropertyT
@@ -49,27 +63,33 @@ propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
 -- from memory leakage caused by, among others, Hedgehog's 'TreeT', which is
 -- used for automatic shrinking (which we don't need in this test).
 propHandleUnicodeCharacters :: Property
-propHandleUnicodeCharacters = property $
-  liftTest $ for_ [minBound .. maxBound] \c ->
-    testRoundTripValue $ VString $ singleton c
+propHandleUnicodeCharacters = property . liftTest $
+  for_ [minBound .. maxBound] $ \char ->
+    roundtripValue . VString $ singleton char
 
 propHandleTripleQuote :: Property
-propHandleTripleQuote = property $ testRoundTripValue $ VString "\"\"\""
+propHandleTripleQuote = property . roundtripValue $ VString "\"\"\""
 
-testRoundTripValue :: MonadTest m => Value Void -> m ()
-testRoundTripValue = testRoundTrip value P.value
+-- | Test that a given 'Value'@ @'Void' passes round-trip tests as expected.
+roundtripValue :: (MonadTest m) => Value Void -> m ()
+roundtripValue = roundtripParser value Printer.value
 
-testRoundTrip ::
-  (Show a, Eq a, MonadTest m) =>
+-- | Test that a pair of parsing/printing functions are compatible with one
+-- another.
+--
+-- That is: given a 'Parser'@ a@ and some @a -> @'Builder', ensure that any
+-- valid @a@ round-trips through the printer and parser to yield the same @a@.
+roundtripParser ::
+  forall a m.
+  (MonadTest m, Eq a, Show a) =>
   Parser a ->
   (a -> Builder) ->
   a ->
   m ()
-testRoundTrip parser printer ast = either onError (ast ===) astRoundTrip
+roundtripParser parser printer ast = tripping ast printAST parseAST
   where
-    astRoundTrip = runParser parser printed
-    printed = run $ printer ast
-    onError e = do
-      footnote $ show printed
-      footnote $ unpack e
-      failure
+    parseAST :: Text -> Either Text a
+    parseAST = runParser parser
+
+    printAST :: a -> Text
+    printAST = run . printer

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,7 +10,6 @@ import qualified Data.Text.Encoding.Error as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
 import qualified Data.Text.Lazy.Encoding as TL
-import qualified Data.Text.Prettyprint.Doc.Render.Text as PP
 import Hedgehog
 import Keywords
 import Language.GraphQL.Draft.Generator
@@ -18,6 +17,7 @@ import qualified Language.GraphQL.Draft.Parser as Input
 import qualified Language.GraphQL.Draft.Printer as Output
 import Language.GraphQL.Draft.Syntax
 import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import qualified Text.Builder as TB


### PR DESCRIPTION
Just what it says on the tin: this updates roundtrip tests to use Hegdehog's built-in `tripping` function.

It additionally adds a bit of documentation and uses `PropertyName` rather than the polymorphic `IsString s` when constructing the Hedgehog test group.