### PR TITLE
stream the test output to avoid CI timeout failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: cabal new-build
       - run:
           name: Run tests
-          command: cabal test --test-show-details=streaming
+          command: cabal new-test --test-show-details=streaming --release
           no_output_timeout: 20m
       - save_cache:
           name: Cache Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: cabal new-build
       - run:
           name: Run tests
-          command: cabal run graphql-parser-test -- release
+          command: cabal test --test-show-details=streaming
           no_output_timeout: 20m
       - save_cache:
           name: Cache Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: cabal new-build
       - run:
           name: Run tests
-          command: cabal new-test --test-show-details=streaming --release
+          command: cabal new-test --test-show-details=streaming
           no_output_timeout: 20m
       - save_cache:
           name: Cache Dependencies


### PR DESCRIPTION
When the cabal tests are run in the CI, there's no output streamed of the tests until the tests are completed. Circle CI by default sets a `no-output-timeout` of 10 minutes i.e when there's no output for 10 mins the job will be marked as failed. We've increased the `no-output-timeout` to 20 minutes in [this commit](https://github.com/hasura/graphql-parser-hs/commit/a846aaff071f5b69b3506ff284d2f87461011306). Although tests generally complete in around ~2-3 minutes locally, it takes a really long time in the CI. 

This PR takes advantage of `cabal new-test`'s `--test-show-details=streaming` which streams the result to the STDOUT as it's generated instead of waiting for all the tests to complete first. This may or may not solve our CI times problem, but albeit it's a good thing to have :) 