### PR TITLE
Avoid some effects in the stack to reduce memory consumption

### DIFF
--- a/test/Keywords.hs
+++ b/test/Keywords.hs
@@ -48,6 +48,11 @@ propHandleNewlineString = property $ testRoundTripValue $ VString "\n"
 propHandleControlString :: Property
 propHandleControlString = property $ testRoundTripValue $ VString "\x0011"
 
+-- NB: 'liftTest' is explicitly used to restrict the 'for_' block to operate in
+-- the 'Test' type (i.e. 'type Test = TestT Identity'), as opposed to 'PropertyT
+-- IO'.  The 'Test' monad is a thinner monad stack & therefore doesn't suffer
+-- from memory leakage caused by, among others, Hedgehog's 'TreeT', which is
+-- used for automatic shrinking (which we don't need in this test).
 propHandleUnicodeCharacters :: Property
 propHandleUnicodeCharacters = property $ liftTest $ for_ [minBound..maxBound] \c ->
   testRoundTripValue $ VString $ singleton c


### PR DESCRIPTION
The exhaustive unicode test uses a thick Hedgehog effect stack that includes `TreeT` for automatic shrinking. However, shrinking doesn't make sense for the unicode test. Unfortunately, a couple of the effects in the stack, including `TreeT`, are somewhat leaky (because the internal "shrinking" structure is built up as thunked lists). This PR reduces the effects used for the unicode test, so that some memory leaks are avoided.