### PR TITLE
WIP: Add support for GHC 9.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,13 @@ package *
 
 package graphql-parser
   ghc-options: -j
+
+-- Temporary GHC 9.2 migration stuff (do not merge this to master)
+
+-- Pointing to someone else's version that supports GHC 9.2
+source-repository-package
+  type: git
+  location: https://github.com/patrickt/haskell-hedgehog.git
+  tag: 362d226e2e215e73f7939386e55dcfbd51957e65
+  subdir: hedgehog
+

--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -47,6 +47,7 @@ library
     , template-haskell
     , text
     , text-builder
+    , th-compat
     , th-lift-instances
     , unordered-containers
     , vector

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -548,7 +548,7 @@ data TypeSystemDirectiveLocation
 instance Hashable TypeSystemDirectiveLocation
 instance NFData   TypeSystemDirectiveLocation
 
-liftTypedHashMap :: (Eq k, Hashable k, Lift k, Lift v) => HashMap k v -> Q (TH.TExp (HashMap k v))
+liftTypedHashMap :: (Hashable k, Lift k, Lift v) => HashMap k v -> Q (TH.TExp (HashMap k v))
 liftTypedHashMap a = [|| M.fromList $$(TH.liftTyped $ M.toList a) ||]
 
 inline :: NoFragments var -> FragmentSpread var


### PR DESCRIPTION
This PR adds support for GHC 9.0.

Changes
- https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#typed-th-quotes-and-splices-have-different-types

The changes to support GHC 9.0 have been made in a backwards-compatible manner via `th-compat`.

This PR is a work-in-progress mostly because I have not yet tested it with `graphql-engine`. I just thought to share this work sooner rather than later, for fear that it be repeated.