### PR TITLE
WIP: Support GHC 9.0

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -47,6 +47,7 @@ library
     , template-haskell
     , text
     , text-builder
+    , th-compat
     , th-lift-instances
     , unordered-containers
     , vector


### PR DESCRIPTION
This PR adds support for GHC 9.0.

Changes
- https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#typed-th-quotes-and-splices-have-different-types

The changes to support GHC 9.0 have been made in a backwards-compatible manner via th-compat.

This PR is a work-in-progress mostly because I have not yet tested it with `graphql-engine`. I just thought to share this work sooner rather than later, for fear that it be repeated.