### PR TITLE
Swaps criterion for tasty-bench

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -1,5 +1,4 @@
 import Control.Monad
-import Criterion.Main
 import qualified Data.ByteString.Builder as BS
 import Data.Functor ((<&>))
 import Data.Maybe (catMaybes)
@@ -12,6 +11,7 @@ import Language.GraphQL.Draft.Generator
 import Language.GraphQL.Draft.Parser (parseExecutableDoc)
 import Language.GraphQL.Draft.Printer
 import Language.GraphQL.Draft.Syntax
+import Test.Tasty.Bench
 import qualified Text.Builder as TB
 
 genDocs :: Int -> IO [(Int, ExecutableDocument Name)]

--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -43,9 +43,6 @@ common common-all
     StrictData
     TupleSections
 
-common common-exe
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-
 library
   import:          common-all
   hs-source-dirs:  src
@@ -75,7 +72,8 @@ library
     Language.GraphQL.Draft.Syntax
 
 test-suite graphql-parser-test
-  import:           common-all, common-exe
+  import:           common-all
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
@@ -97,15 +95,15 @@ test-suite graphql-parser-test
   default-language: Haskell2010
 
 benchmark graphql-parser-bench
-  import:         common-all, common-exe
+  import:         common-all
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench
   main-is:        Benchmark.hs
   build-depends:
     , base            >=4.7 && <5
     , bytestring
-    , criterion
     , graphql-parser
     , prettyprinter
+    , tasty-bench
     , text
     , text-builder


### PR DESCRIPTION
Just what it says on the tin.

`tasty-bench` has a _much_ lighter dependency footprint than `criterion`, and it also fails the benchmark suite if it's run in threaded/multicore mode (since this distorts benchmarks).