### PR TITLE
SchemaIntrospection now indexes types by their name.

### DIFF
--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -227,10 +227,11 @@ instance J.FromJSON SchemaDocument where
       Left err -> fail $ "parsing the schema document: " <> show err
 
 -- | A variant of 'SchemaDocument' that additionally stores, for each interface,
--- the list of object types that implement that interface
+-- the list of object types that implement that interface. Types are indexed by
+-- their name for fast lookups.
 newtype SchemaIntrospection
-  = SchemaIntrospection [TypeDefinition [Name] InputValueDefinition]
-  deriving stock (Eq, Generic, Lift, Ord, Show)
+  = SchemaIntrospection (HashMap Name (TypeDefinition [Name] InputValueDefinition))
+  deriving stock (Eq, Generic, Ord, Show)
   deriving newtype (Hashable)
 
 data OperationDefinition frag var


### PR DESCRIPTION
### Description

Our only use of such "introspection results" is to traverse them, starting from one of the root types. In the engine, we have switched every similar representation to a `HashMap`; doing the same in the library directly will remove some duplication, and is a net upgrade.