### PR TITLE
Format-string quasiquotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ ghcid:
 	    graphql-parser \
 	  "
 
+.PHONY: repl
+repl:
+	$(CABAL) repl \
+	    --repl-option='-fobject-code' \
+	    --repl-option='-O0' \
+	    graphql-parser
+
 .PHONY: ghcid-test
 ghcid-test:
 	ghcid \

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,35 @@ format:
 	find src test bench \
 	  -type f \( -name "*.hs" -o -name "*.hs-boot" \) | \
 	  xargs ormolu -ie
+
+PROJECT ?= cabal.project
+CABAL = cabal --project=$(PROJECT)
+
+.PHONY: build-deps
+build-deps:
+	$(CABAL) build \
+	  --only-dependencies \
+	  --enable-tests \
+	  --enable-benchmarks \
+	  all
+
+.PHONY: ghcid
+ghcid:
+	ghcid --command "\
+	  $(CABAL) repl \
+	    --repl-option='-fobject-code' \
+	    --repl-option='-O0' \
+	    graphql-parser \
+	  "
+
+.PHONY: ghcid-test
+ghcid-test:
+	ghcid \
+	  --command "\
+	    $(CABAL) repl \
+	      --repl-option '-fobject-code' \
+	      --repl-option '-O0' \
+	      graphql-parser-test \
+	    " \
+	--test ":main"
+

--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -73,6 +73,7 @@ library
     , hashable              >=1.3
     , hedgehog              >=1.1
     , prettyprinter         >=1.7
+    , PyF                   >=0.10
     , scientific            >=0.3
     , template-haskell      >=2.16
     , text                  >=1.2

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -8,6 +8,7 @@ module Language.GraphQL.Draft.Syntax
     unName,
     mkName,
     unsafeMkName,
+    parseName,
     litName,
     Description (..),
     Value (..),

--- a/src/Language/GraphQL/Draft/Syntax/QQ.hs
+++ b/src/Language/GraphQL/Draft/Syntax/QQ.hs
@@ -10,6 +10,7 @@
 module Language.GraphQL.Draft.Syntax.QQ
   ( name,
     executableDoc,
+    executableDocFmt,
   )
 where
 
@@ -19,7 +20,6 @@ import Data.Text qualified as Text
 import Language.GraphQL.Draft.Parser (parseExecutableDoc)
 import Language.GraphQL.Draft.Syntax qualified as Syntax
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
-import Language.Haskell.TH.Syntax (lift)
 import PyF (fmtConfig)
 import PyF.Internal.QQ (toExp)
 import Prelude
@@ -27,6 +27,17 @@ import Prelude
 -------------------------------------------------------------------------------
 
 -- | Construct 'Syntax.Name' literals at compile-time via quasiquotation.
+--
+-- This quasiquoter supports Python-style "f-string" interpolation.
+--
+-- For example, if one had some value @barLit = "bar"@ present in-scope, then
+-- the following quasiquotation:
+--
+-- @
+-- [name|foo_{barLit}|]
+-- @
+--
+-- ...would produce a 'Syntax.Name' value with the value @foo_bar@.
 name :: QuasiQuoter
 name =
   QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
@@ -40,6 +51,21 @@ name =
 
 -- | Construct @'Syntax.ExecutableDocument' 'Syntax.Name'@ literals at compile
 -- time via quasiquotation.
+--
+-- This quasiquoter does not support Python-style "f-string" interpolation,
+-- unlike 'executableDocFmt', which means that GraphQL document literals can be
+-- produced using their natural syntax:
+--
+-- @
+-- [executableDoc|
+-- {
+--   hero {
+--     name
+--     age
+--   }
+-- }
+-- |]
+-- @
 executableDoc :: QuasiQuoter
 executableDoc =
   QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
@@ -47,6 +73,48 @@ executableDoc =
     quotePat _ = error "'executableDoc' does not support quoting patterns"
     quoteType _ = error "'executableDoc' does not support quoting types"
     quoteDec _ = error "'executableDoc' does not support quoting declarations"
-    quoteExp s = case parseExecutableDoc (Text.pack s) of
-      Left err -> fail $ show err
-      Right result -> lift result
+    quoteExp str = case (parseExecutableDoc . Text.pack $ str) of
+      Left err -> fail . show $ err
+      Right doc -> [|doc|]
+
+-- | Construct @'Syntax.ExecutableDocument' 'Syntax.Name'@ literals at compile
+-- time via quasiquotation.
+--
+-- Unlike 'executableDoc', this quasiquoter supports interpolation at the
+-- expense of overloading the braces normally used to define GraphQL documents.
+--
+-- For example, if one were to write the following quasiquotation, with
+-- @nameLit = "name"@ in-scope:
+--
+-- @
+-- [executableDocFmt|
+-- {{
+--   hero {{
+--     {nameLit}
+--     age
+--   }}
+-- }}
+-- |]
+-- @
+--
+-- ...then the following document literal would be produced:
+--
+-- @
+-- {
+--   hero {
+--     name
+--     age
+--   }
+-- }
+-- @
+executableDocFmt :: QuasiQuoter
+executableDocFmt =
+  QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
+  where
+    quotePat _ = error "'executableDocFmt' does not support quoting patterns"
+    quoteType _ = error "'executableDocFmt' does not support quoting types"
+    quoteDec _ = error "'executableDocFmt' does not support quoting declarations"
+    quoteExp str = do
+      let formattedStrExpQ = toExp fmtConfig str
+          docExpQ = [|parseExecutableDoc . Text.pack $ $(formattedStrExpQ)|]
+      [|either (fail . show) pure $(docExpQ)|]

--- a/src/Language/GraphQL/Draft/Syntax/QQ.hs
+++ b/src/Language/GraphQL/Draft/Syntax/QQ.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Quasiquotation for 'Language.GraphQL.Draft.Syntax' types.
 --
@@ -17,7 +20,8 @@ import Language.GraphQL.Draft.Parser (parseExecutableDoc)
 import Language.GraphQL.Draft.Syntax qualified as Syntax
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax (lift)
-import Language.Haskell.TH.Syntax.Compat (examineSplice, unTypeQQuote)
+import PyF (fmtConfig)
+import PyF.Internal.QQ (toExp)
 import Prelude
 
 -------------------------------------------------------------------------------
@@ -27,10 +31,12 @@ name :: QuasiQuoter
 name =
   QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
   where
-    quotePat _ = error "executableDoc does not support quoting patterns"
-    quoteType _ = error "executableDoc does not support quoting types"
-    quoteDec _ = error "executableDoc does not support quoting declarations"
-    quoteExp = unTypeQQuote . examineSplice . Syntax.litName . Text.pack
+    quotePat _ = error "'name' does not support quoting patterns"
+    quoteType _ = error "'name' does not support quoting types"
+    quoteDec _ = error "'name' does not support quoting declarations"
+    quoteExp str = do
+      let formattedStrExpQ = toExp fmtConfig str
+      [|Syntax.parseName . Text.pack $ $(formattedStrExpQ)|]
 
 -- | Construct @'Syntax.ExecutableDocument' 'Syntax.Name'@ literals at compile
 -- time via quasiquotation.
@@ -38,9 +44,9 @@ executableDoc :: QuasiQuoter
 executableDoc =
   QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
   where
-    quotePat _ = error "executableDoc does not support quoting patterns"
-    quoteType _ = error "executableDoc does not support quoting types"
-    quoteDec _ = error "executableDoc does not support quoting declarations"
+    quotePat _ = error "'executableDoc' does not support quoting patterns"
+    quoteType _ = error "'executableDoc' does not support quoting types"
+    quoteDec _ = error "'executableDoc' does not support quoting declarations"
     quoteExp s = case parseExecutableDoc (Text.pack s) of
       Left err -> fail $ show err
       Right result -> lift result


### PR DESCRIPTION
Adds Python-style "f-string" quasiquotation to the `name` quasiquoter, and adds a new `ExecutableDocument` quasiquoter which also supports "f-string" quasiquotation.