### PR TITLE
Disables project caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,6 @@ jobs:
             --enable-tests \
             --enable-benchmarks
 
-      - name: Cache library, test, and benchmark artifacts.
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./dist-nestyle
-          key: ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{ hashFiles('./graphql-parser.cabal') }}
-          restore-keys: ${{ runner.os }}-cabal-${{ matrix.ghc }}-
-
       - name: Compile library, tests, and benchmarks.
         run: |
           ${CABAL} build graphql-parser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           path: |
             ${{ steps.set-up-haskell-tooling.outputs.cabal-store }}
-          key: ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{ hashFiles('./ci/ci.project.freeze') }}
-          restore-keys: ${{ runner.os }}-cabal-${{ matrix.ghc }}-
+          key: ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{ hashFiles('./ci/ci.project.freeze') }}-0
+          restore-key: ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{ hashFiles('./ci/ci.project.freeze') }}-0
 
       - name: Compile dependencies.
         run: |


### PR DESCRIPTION
Looks like #74 didn't do the trick; something's up with trying to        
restore from the local project cache.

It appears as if GHC is rebuilding some library dependencies in one
build step, but attempting to restore a version of the local project
cache that was compiled against an earlier version of that library.

This probably means that the cache restore key should be a bit more
granular (perhaps it should depend on the freeze file hash, which would
mean that older snapshots of the local cache would never restore in the
presence of a newer Hackage snapshot).