### PR TITLE
Factor out `Name` into its own (re-exported) module.

### DIFF
--- a/graphql-parser.cabal
+++ b/graphql-parser.cabal
@@ -82,8 +82,6 @@ library
     , th-lift-instances     >=0.1
     , unordered-containers  >=0.2
 
-  -- cabal-fmt: expand src
-  --
   exposed-modules:
     Language.GraphQL.Draft.Generator
     Language.GraphQL.Draft.Parser
@@ -91,6 +89,9 @@ library
     Language.GraphQL.Draft.Syntax
     Language.GraphQL.Draft.Syntax.Internal
     Language.GraphQL.Draft.Syntax.QQ
+
+  other-modules:
+    Language.GraphQL.Draft.Syntax.Name
 
 test-suite graphql-parser-test
   import:         common-all

--- a/src/Language/GraphQL/Draft/Parser.hs
+++ b/src/Language/GraphQL/Draft/Parser.hs
@@ -56,6 +56,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Void (Void)
 import Language.GraphQL.Draft.Syntax qualified as AST
+import Language.GraphQL.Draft.Syntax.Name qualified as Name
 import Prelude
 
 -------------------------------------------------------------------------------
@@ -269,7 +270,7 @@ objectFields several = foldM insertField M.empty =<< several objectField
   where
     objectField = (,) <$> nameParser <* tok ":" <*> value
     insertField obj (k, v)
-      | k `M.member` obj = fail $ "multiple “" <> T.unpack (AST.unName k) <> "” fields"
+      | k `M.member` obj = fail $ "multiple “" <> T.unpack (Name.unName k) <> "” fields"
       | otherwise = pure (M.insert k v obj)
 
 -- * Directives

--- a/src/Language/GraphQL/Draft/Parser.hs-boot
+++ b/src/Language/GraphQL/Draft/Parser.hs-boot
@@ -8,9 +8,10 @@ where
 
 import Data.Text (Text)
 import {-# SOURCE #-} Language.GraphQL.Draft.Syntax qualified as AST
+import Language.GraphQL.Draft.Syntax.Name (Name)
 import Prelude (Either)
 
 -------------------------------------------------------------------------------
 
-parseExecutableDoc :: Text -> Either Text (AST.ExecutableDocument AST.Name)
+parseExecutableDoc :: Text -> Either Text (AST.ExecutableDocument Name)
 parseSchemaDocument :: Text -> Either Text AST.SchemaDocument

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -23,6 +23,7 @@ import Data.Text.Lazy.Builder.Scientific qualified as LTBS
 import Data.Text.Lazy.Encoding qualified as LTE
 import Data.Void (Void, absurd)
 import Language.GraphQL.Draft.Syntax
+import Language.GraphQL.Draft.Syntax.Name qualified as Name
 import Prettyprinter qualified as PP
 import Text.Builder qualified as Text
 import Prelude
@@ -39,7 +40,7 @@ class (Monoid a, IsString a) => Printer a where
   {-# MINIMAL textP, charP, intP, doubleP #-}
 
   nameP :: Name -> a
-  nameP = textP . unName
+  nameP = textP . Name.unName
 
   nodeP :: (Print (frag var), Print var) => TypedOperationDefinition frag var -> a
   nodeP = node

--- a/src/Language/GraphQL/Draft/Printer.hs-boot
+++ b/src/Language/GraphQL/Draft/Printer.hs-boot
@@ -6,10 +6,8 @@ where
 -------------------------------------------------------------------------------
 
 import Data.Text (Text)
-import {-# SOURCE #-} Language.GraphQL.Draft.Syntax
-  ( ExecutableDocument,
-    Name,
-  )
+import {-# SOURCE #-} Language.GraphQL.Draft.Syntax (ExecutableDocument)
+import Language.GraphQL.Draft.Syntax.Name (Name)
 
 -------------------------------------------------------------------------------
 

--- a/src/Language/GraphQL/Draft/Syntax.hs
+++ b/src/Language/GraphQL/Draft/Syntax.hs
@@ -96,15 +96,12 @@ import Control.DeepSeq (NFData)
 import Data.Aeson qualified as J
 import Data.Bifunctor (Bifunctor (bimap))
 import Data.Bool (bool)
-import Data.Char qualified as C
-import Data.Coerce (coerce)
 import Data.HashMap.Strict (HashMap)
 import Data.Hashable (Hashable)
 import Data.Kind (Type)
 import Data.Scientific (Scientific)
 import Data.String (IsString (..))
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Void (Void, absurd)
 import GHC.Generics (Generic)
 import Instances.TH.Lift ()
@@ -114,104 +111,12 @@ import {-# SOURCE #-} Language.GraphQL.Draft.Parser
   )
 import {-# SOURCE #-} Language.GraphQL.Draft.Printer (renderExecutableDoc)
 import Language.GraphQL.Draft.Syntax.Internal (liftTypedHashMap)
+import Language.GraphQL.Draft.Syntax.Name
 import Language.Haskell.TH.Syntax (Lift)
 import Language.Haskell.TH.Syntax qualified as TH
-import Language.Haskell.TH.Syntax.Compat (SpliceQ, examineSplice, liftSplice)
-import Prettyprinter (Pretty (..))
 import Prelude
 
 -------------------------------------------------------------------------------
-type Name :: Type
-newtype Name = Name {unName :: Text}
-  deriving stock (Eq, Lift, Ord, Show)
-  deriving newtype (Hashable, NFData, Pretty, Semigroup, J.ToJSONKey, J.ToJSON)
-
--- | @NameSuffix@ is essentially a GQL identifier that can be used as Suffix
---  It is slightely different from @Name@ as it relaxes the criteria that a
---  @Name@ cannot start with a digit.
-type NameSuffix :: Type
-newtype NameSuffix = Suffix {unNameSuffix :: Text}
-  deriving stock (Lift, Show)
-
--- | @matchFirst@ verifies if the starting character is according to the
---  graphql spec (refer https://spec.graphql.org/October2021/#NameStart).
-matchFirst :: Char -> Bool
-matchFirst c = c == '_' || C.isAsciiUpper c || C.isAsciiLower c
-
--- | @matchBody@ verifies if the continuing character is according to the
---  graphql spec (refer https://spec.graphql.org/October2021/#NameContinue).
-matchBody :: Char -> Bool
-matchBody c = c == '_' || C.isAsciiUpper c || C.isAsciiLower c || C.isDigit c
-
--- | @isValidName@ verifies if a text is a valid @Name@ as per the graphql
---  spec (refer https://spec.graphql.org/October2021/#Name)
-isValidName :: Text -> Bool
-isValidName text =
-  case T.uncons text of
-    Nothing -> False
-    Just (first, body) ->
-      matchFirst first && T.all matchBody body
-
-mkName :: Text -> Maybe Name
-mkName text =
-  if isValidName text
-    then Just (Name text)
-    else Nothing
-
-mkNameSuffix :: Text -> Maybe NameSuffix
-mkNameSuffix text =
-  if T.all matchBody text
-    then Just (Suffix text)
-    else Nothing
-
-addSuffixes :: Name -> [NameSuffix] -> Name
-addSuffixes prefix [] = prefix
-addSuffixes (Name prefix) suffs = Name $ T.concat (prefix : suffsT)
-  where
-    suffsT = map unNameSuffix suffs
-
--- | All @Name@s are @Suffix@, so this function won't fail
-convertNameToSuffix :: Name -> NameSuffix
-convertNameToSuffix = coerce
-
-unsafeMkName :: Text -> Name
-unsafeMkName = Name
-
-parseName :: MonadFail m => Text -> m Name
-parseName text = maybe (fail errorMessage) pure $ mkName text
-  where
-    errorMessage = T.unpack text <> " is not valid GraphQL name"
-
-parseSuffix :: MonadFail m => Text -> m NameSuffix
-parseSuffix text = maybe (fail errorMessage) pure $ mkNameSuffix text
-  where
-    errorMessage = T.unpack text <> " is not valid GraphQL suffix"
-
--- | Construct a 'Name' value at compile-time.
-litName :: Text -> SpliceQ Name
-litName txt = liftSplice do
-  name <- parseName txt
-  examineSplice [||name||]
-
--- | Construct a 'NameSuffix' value at compile-time.
-litSuffix :: Text -> SpliceQ NameSuffix
-litSuffix txt = liftSplice do
-  name <- parseSuffix txt
-  examineSplice [||name||]
-
--- | Construct prefix-suffix tuple at compile-time from a list.
-litGQLIdentifier :: [Text] -> SpliceQ (Name, [NameSuffix])
-litGQLIdentifier [] = liftSplice $ fail "GQL identifier cannot be empty"
-litGQLIdentifier (x : xs) = liftSplice do
-  pref <- parseName x
-  suffs <- traverse parseSuffix xs
-  examineSplice [||(pref, suffs)||]
-
-instance J.FromJSON Name where
-  parseJSON = J.withText "Name" parseName
-
-instance J.FromJSONKey Name where
-  fromJSONKey = J.FromJSONKeyTextParser parseName
 
 -- * Documents
 

--- a/src/Language/GraphQL/Draft/Syntax.hs-boot
+++ b/src/Language/GraphQL/Draft/Syntax.hs-boot
@@ -1,6 +1,5 @@
 module Language.GraphQL.Draft.Syntax
   ( ExecutableDocument,
-    Name,
     SchemaDocument,
   )
 where
@@ -8,9 +7,6 @@ where
 import Data.Kind (Type)
 
 -------------------------------------------------------------------------------
-
-type Name :: Type
-data Name
 
 type role ExecutableDocument nominal
 

--- a/src/Language/GraphQL/Draft/Syntax/Name.hs
+++ b/src/Language/GraphQL/Draft/Syntax/Name.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+-- | Internal functionality for Name values.
+--
+-- This module is necessary to avoid exposing `unName` and friends to the outside world.
+module Language.GraphQL.Draft.Syntax.Name
+  ( Name (..),
+    NameSuffix (..),
+    mkName,
+    unsafeMkName,
+    parseName,
+    mkNameSuffix,
+    parseSuffix,
+    isValidName,
+    addSuffixes,
+    convertNameToSuffix,
+    litName,
+    litSuffix,
+    litGQLIdentifier,
+  )
+where
+
+-------------------------------------------------------------------------------
+
+import Control.DeepSeq (NFData)
+import Data.Aeson qualified as J
+import Data.Char qualified as C
+import Data.Coerce (coerce)
+import Data.Hashable (Hashable)
+import Data.Kind (Type)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Instances.TH.Lift ()
+import Language.Haskell.TH.Syntax (Lift)
+import Language.Haskell.TH.Syntax.Compat (SpliceQ, examineSplice, liftSplice)
+import Prettyprinter (Pretty (..))
+import Prelude
+
+-------------------------------------------------------------------------------
+
+-- Defined here and re-exported in the public module to avoid exporting `unName`.`
+type Name :: Type
+newtype Name = Name {unName :: Text}
+  deriving stock (Eq, Lift, Ord, Show)
+  deriving newtype (Hashable, NFData, Pretty, J.ToJSONKey, J.ToJSON)
+
+-- | @NameSuffix@ is essentially a GQL identifier that can be used as Suffix
+--  It is slightely different from @Name@ as it relaxes the criteria that a
+--  @Name@ cannot start with a digit.
+type NameSuffix :: Type
+newtype NameSuffix = Suffix {unNameSuffix :: Text}
+  deriving stock (Lift, Show)
+
+parseName :: MonadFail m => Text -> m Name
+parseName text = maybe (fail errorMessage) pure $ mkName text
+  where
+    errorMessage = T.unpack text <> " is not valid GraphQL name"
+
+-- | @matchFirst@ verifies if the starting character is according to the
+--  graphql spec (refer https://spec.graphql.org/October2021/#NameStart).
+matchFirst :: Char -> Bool
+matchFirst c = c == '_' || C.isAsciiUpper c || C.isAsciiLower c
+
+-- | @matchBody@ verifies if the continuing character is according to the
+--  graphql spec (refer https://spec.graphql.org/October2021/#NameContinue).
+matchBody :: Char -> Bool
+matchBody c = c == '_' || C.isAsciiUpper c || C.isAsciiLower c || C.isDigit c
+
+-- | @isValidName@ verifies if a text is a valid @Name@ as per the graphql
+--  spec (refer https://spec.graphql.org/October2021/#Name)
+isValidName :: Text -> Bool
+isValidName text =
+  case T.uncons text of
+    Nothing -> False
+    Just (first, body) ->
+      matchFirst first && T.all matchBody body
+
+mkName :: Text -> Maybe Name
+mkName text =
+  if isValidName text
+    then Just (Name text)
+    else Nothing
+
+mkNameSuffix :: Text -> Maybe NameSuffix
+mkNameSuffix text =
+  if T.all matchBody text
+    then Just (Suffix text)
+    else Nothing
+
+addSuffixes :: Name -> [NameSuffix] -> Name
+addSuffixes prefix [] = prefix
+addSuffixes (Name prefix) suffs = Name $ T.concat (prefix : suffsT)
+  where
+    suffsT = map unNameSuffix suffs
+
+-- | All @Name@s are @Suffix@, so this function won't fail
+convertNameToSuffix :: Name -> NameSuffix
+convertNameToSuffix = coerce
+
+unsafeMkName :: Text -> Name
+unsafeMkName = Name
+
+parseSuffix :: MonadFail m => Text -> m NameSuffix
+parseSuffix text = maybe (fail errorMessage) pure $ mkNameSuffix text
+  where
+    errorMessage = T.unpack text <> " is not valid GraphQL suffix"
+
+-- | Construct a 'Name' value at compile-time.
+litName :: Text -> SpliceQ Name
+litName txt = liftSplice do
+  name <- parseName txt
+  examineSplice [||name||]
+
+-- | Construct a 'NameSuffix' value at compile-time.
+litSuffix :: Text -> SpliceQ NameSuffix
+litSuffix txt = liftSplice do
+  name <- parseSuffix txt
+  examineSplice [||name||]
+
+-- | Construct prefix-suffix tuple at compile-time from a list.
+litGQLIdentifier :: [Text] -> SpliceQ (Name, [NameSuffix])
+litGQLIdentifier [] = liftSplice $ fail "GQL identifier cannot be empty"
+litGQLIdentifier (x : xs) = liftSplice do
+  pref <- parseName x
+  suffs <- traverse parseSuffix xs
+  examineSplice [||(pref, suffs)||]
+
+instance J.FromJSON Name where
+  parseJSON = J.withText "Name" parseName
+
+instance J.FromJSONKey Name where
+  fromJSONKey = J.FromJSONKeyTextParser parseName

--- a/src/Language/GraphQL/Draft/Syntax/Name.hs-boot
+++ b/src/Language/GraphQL/Draft/Syntax/Name.hs-boot
@@ -1,0 +1,8 @@
+module Language.GraphQL.Draft.Syntax.Name (Name) where
+
+import Data.Kind (Type)
+
+-------------------------------------------------------------------------------
+
+type Name :: Type
+data Name


### PR DESCRIPTION
This is in preparation for hiding the `unName` and `unNameSuffix`
functions. There are very few reasons to deconstruct a `Name` or
`NameSuffix`; we may be able to eliminate all of them.