### PR TITLE
Add a Nix flake to provide tooling and build the library.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-*~
-dist-newstyle/
+# Haskell
+/dist-newstyle
 cabal.project.local
-.direnv/*
+
+# direnv
+/.direnv
+/.envrc.local
+
+# Nix
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656754140,
+        "narHash": "sha256-8thJUtZWIimyBtkYQ0tdmmnH0yJvOaw1K5W3OgKc6/A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "09c32b0bda4db98d6454e910206188e85d5b04cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+# To automatically load this flake into your shell:
+#   1. Set up direnv and nix-direnv.
+#   2. Create a file named ".envrc.local", with the contents `use flake`.
+
+{
+  description = "Hasura GraphQL Engine";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+
+    flake-utils = {
+      url = github:numtide/flake-utils;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    }:
+    let
+      ghcVersion = "8.10.7";
+      ghcName = "ghc${builtins.replaceStrings ["."] [""] ghcVersion}";
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      haskellCompiler = pkgs.haskell.compiler."${ghcName}";
+      haskellPackages = pkgs.haskell.packages."${ghcName}";
+    in
+    {
+      packages.default = (haskellPackages.callCabal2nix "graphql-parser" ./. { }).overrideScope (
+        self: super: {
+          hedgehog = self.hedgehog_1_1_1;
+        }
+      );
+
+      pkgs.formatter = nixpkgs.legacyPackages."${system}".nixpkgs-fmt;
+
+      devShells.default = pkgs.mkShell {
+        name = "graphql-parser-hs";
+
+        # We list top-level packages before packages scoped to the GHC version, so
+        # that they appear first in the PATH. Otherwise we might end up with older
+        # versions of transitive dependencies (e.g. HLS depending on Ormolu).
+        buildInputs = [
+          pkgs.cabal-install
+          pkgs.hlint
+          pkgs.ormolu
+          haskellCompiler
+          haskellPackages.ghcid
+          haskellPackages.haskell-language-server
+        ];
+      };
+    }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,12 @@
   description = "Hasura GraphQL Engine";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+    nixpkgs = {
+      url = github:NixOS/nixpkgs/nixos-22.05;
+    };
 
     flake-utils = {
       url = github:numtide/flake-utils;
-      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ system ? builtins.currentSystem }:
+
+(builtins.getFlake (toString ./.)).devShells.${system}


### PR DESCRIPTION
The flake.lock file is copied from hasura/graphql-engine to keep things
simpler (for me, at least).

This is all optional and opt-in, typically by adding a .envrc.local file
containing `use flake`.