### PR TITLE
Add notice to new location of library code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ A GraphQL parsing library for Haskell. Used at Hasura in various production
 projects.
 
 The code for this library has now moved to another git repository, and can be
-found here:
+found in the
 [graphql-engine](https://github.com/hasura/graphql-engine/tree/master/server/lib/graphql-parser-hs) repository.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![build status](https://img.shields.io/github/workflow/status/hasura/graphql-parser-hs/ci/main?label=build%20status&logo=github&style=flat-square)](https://github.com/hasura/graphql-parser-hs/actions?query=workflow%3Aci+branch%3Amain)
 
+A GraphQL parsing library for Haskell. Used at Hasura in various production
+projects.
 
-## Style
+The code for this library has now moved to another git repository, and can be
+found here:
+[graphql-engine](https://github.com/hasura/graphql-engine/tree/master/server/lib/graphql-parser-hs) repository.
 
-This repository follows the graphql-engine
-[style guide](https://github.com/hasura/graphql-engine/blob/master/server/STYLE.md).
-
-Use `make format` to run the formatter.


### PR DESCRIPTION
This library has been moved into the `graphql-engine` repository, and will be developed from there in future. This PR adds a notice to this effect. Once it is merged, the repository should also be archived.